### PR TITLE
Add package.json draft.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "evaporate",
+  "version": "0.0.2",
+  "description": "Javascript library for browser to S3 multipart resumable uploads",
+  "main": "evaporate.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TTLabs/EvaporateJS.git"
+  },
+  "keywords": [
+    "aws",
+    "S3",
+    "uploads",
+    "browser"
+  ],
+  "bugs": {
+    "url": "https://github.com/TTLabs/EvaporateJS/issues"
+  },
+  "author": {
+    "name": "Tom Saffell",
+    "email": "tcs@videopixie.com"
+  },
+  "license": "BSD-2-Clause",
+  "homepage": "https://github.com/TTLabs/EvaporateJS"
+}


### PR DESCRIPTION
Hopefully this at least partially fulfils the request in #22. The
"author"[1] and "license"[2] fields are missing, as I didn't know what
to fill in there. Most other aspects seem to be ok. The package name
"evaporate" instead of "EvaporateJS" was chosen, following npm's
standard naming conventions[3], but feel free to change that, of course.

[1] - https://www.npmjs.org/doc/json.html#people-fields-author-contributors
[2] - https://www.npmjs.org/doc/json.html#license
[3] - https://www.npmjs.org/doc/json.html#name
