### PR TITLE
Ensuring Evaporate is in the global scope

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -24,7 +24,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ***************************************************************************************************/
 
 
-var Evaporate = function(config){
+window.Evaporate = function(config){
 
    this.supported = !((typeof(File)=='undefined') ||
       (typeof(Blob)=='undefined') ||


### PR DESCRIPTION
This keeps it from breaking when used with a requirejs shim that expects it to be in the global scope, and concatenation scripts that wrap everything in a closure.

There'd probably be a more comprehensive way of dealing with require, but this was the bare minimum it took for me to get it to work again.
