### PR TITLE
Add support for custom request headers which should not be signed by the secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ So far the api contains just two methods, and one property
 `config` has 4 optional parameter:
 
 
-* **xAmzHeadersAtInitiate**: _Object_. an object of key/value pairs that represents the x-amz-... headers that should be added to the initiate POST to S3 (not added to the part PUTS, or the complete POST). An example would be `{'x-amz-acl':'public-read'}`
+* **xAmzHeadersAtInitiate**: _Object_. an object of key/value pairs that represents the x-amz-... headers that should be added to the initiate POST to S3 (not added to the part PUTS, or the complete POST) and should be signed by the aws secret key. An example would be `{'x-amz-acl':'public-read'}`
+
+* **notSignedHeadersAtInitiate**: _Object_. an object of key/value pairs that represents the headers that should be added to the initiate POST to S3 (not added to the part PUTS, or the complete POST). An example would be `{'Cache-Control':'max-age=3600'}`
 
 * **signParams**: _Object_. an object of key/value pairs that will be passed to _all_ calls to the signerUrl. 
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -229,7 +229,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               method: 'POST',
               path: '/' + con.bucket + '/' + me.name + '?uploads',
               step: 'initiate',
-              x_amz_headers: me.xAmzHeadersAtInitiate
+              x_amz_headers: me.xAmzHeadersAtInitiate,
+              not_signed_headers: me.notSignedHeadersAtInitiate
            };
 
            if (me.contentType){
@@ -576,6 +577,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               requester.awsXhr = xhr;
               var payload = requester.toSend ? requester.toSend() : null;
               var url = AWS_URL + requester.path;
+              var all_headers = {};
+              extend(all_headers, requester.not_signed_headers);
+              extend(all_headers, requester.x_amz_headers);
 
               if (con.simulateErrors && requester.attempts == 1 &&requester.step == 'upload #3'){
                  l.d('simulating error by POST part #3 to invalid url');
@@ -585,14 +589,14 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               xhr.open(requester.method, url);
               xhr.setRequestHeader('Authorization', 'AWS ' + con.aws_key + ':' + requester.auth);
 
-              if (requester.contentType){
-                 xhr.setRequestHeader('Content-Type', requester.contentType);
+              for (var key in all_headers) {
+                 if (all_headers.hasOwnProperty(key)) {
+                    xhr.setRequestHeader(key, all_headers[key]);
+                 }
               }
 
-              for (var key in requester.x_amz_headers) {
-                 if (requester.x_amz_headers.hasOwnProperty(key)) {
-                    xhr.setRequestHeader(key, requester.x_amz_headers[key]);
-                 }
+              if (requester.contentType){
+                 xhr.setRequestHeader('Content-Type', requester.contentType);
               }
 
               xhr.onreadystatechange = function(){

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -38,6 +38,9 @@
                _e_.add({
                   name: 'test_' + Math.floor(1000000000*Math.random()),
                   file: files[i],
+                  notSignedHeadersAtInitiate: {
+                     'Cache-Control': 'max-age=3600'
+                  },
                   xAmzHeadersAtInitiate : {
                      'x-amz-acl': 'public-read'
                   },


### PR DESCRIPTION
.. e.g. `Cache-Control` or `Expires`. More about not `x-amz-*`-like headers here: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
