### PR TITLE
Add ability to send x-amz-headers with upload and complete

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -280,6 +280,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               method: 'PUT',
               path: getPath() + '?partNumber='+partNumber+'&uploadId='+me.uploadId,
               step: 'upload #' + partNumber,
+              x_amz_headers: me.xAmzHeadersAtUpload,
               attempts: part.attempts
            };
            // TODO: add md5
@@ -398,6 +399,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               method: 'POST',
               contentType: 'application/xml; charset=UTF-8',
               path: getPath() + '?uploadId='+me.uploadId,
+              x_amz_headers: me.xAmzHeadersAtComplete,
               step: 'complete'
            };
 


### PR DESCRIPTION
This is needed when using **x-amz-security-token**, which is a needed header
when using temporary security credentials.
See AWS doc for details:
http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#UsingTemporarySecurityCredentials

Note: To get temporary security credentials I set x-amz-security-token in all three spots: xAmzHeadersAtInitiate, xAmzHeadersAtUpload, and xAmzHeadersAtComplete.

Temporary security credentials are useful when you want to use IAM roles and not provide your permanent keys.
