### PR TITLE
Adding /<bucket>/ to the url to sign when in cloudfront

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -697,6 +697,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               (request.contentType || '')+'\n'+
               '\n'+
               x_amz_headers +
+              (con.cloudfront ? '/' + con.bucket : '')+
               request.path;
            return encodeURIComponent(to_sign);
         }


### PR DESCRIPTION
Currently Cloudfront is a bit broken on Evaporate.

Cloudfront directs queries directed at /resource to S3 in the form /bucket/resource, S3 subsequently thinks the URL to compare signing against has form /bucket/resource rather than /resource, so when providing the URL for signing you need to prepend the bucket name.

Its also worth adding a note to your documentation indicating that your Cloudfront distribution needs to enable query string forwarding, which is disabled by default. Otherwise the "?uploads" and whatnot part of the queries are cut out.
