### PR TITLE
don't uri-encode filename twice

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -66,9 +66,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         if (typeof file.name == 'undefined'){
            err = 'Missing attribute: name  ';
         }
-        else{
-      	  file.name = encodeURIComponent(file.name); // prevent signature fail in case file name has spaces 
-        }        
         
         /*if (!(file.file instanceof File)){
            err += '.file attribute must be instanceof File';


### PR DESCRIPTION
Hi, Tom!
Pulled an update of this lib recently and it had stopped working properly for me. The problem is `encodeURIComponent()` getting called twice on the same filename. I see your comment: "prevent signature fail in case file name has spaces", but can't really guess why can this happen (you will encode `to_sign` string anyway). I haven't much time now to test filenames with spaces though.. So just consider my pull request, because you obviously know things better.