### PR TITLE
Correct name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "EvaporateJS",
+  "name": "evaporatejs",
   "version": "0.0.2",
   "description": "Javascript library for browser to S3 multipart resumable uploads",
   "main": "evaporate.js",


### PR DESCRIPTION
Bower uses case sensitive search/install, and this package is registered
with the name "evaporatejs", not "EvaporateJS":

```
$ bower i --save EvaporateJS
bower                        ENOTFOUND Package EvaporateJS not found

$ bower i --save evaporatejs
...
bower evaporatejs#*            install evaporatejs#33acaf40e9
evaporatejs#33acaf40e9 vendor/assets/components/evaporatejs

```