### PR TITLE
Robust access to signer request

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -708,6 +708,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            };
 
            xhr.open('GET', url);
+           if( me.beforeSigner instanceof Function ) {
+             me.beforeSigner(xhr);
+           }
            xhr.send();
         }
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -665,8 +665,21 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
            for (var param in me.signParams) {
               if (!me.signParams.hasOwnProperty(param)) {continue;}
-              url += ('&'+encodeURIComponent(param)+'='+encodeURIComponent(me.signParams[param]));
+             if( me.signParams[param] instanceof Function ) {
+               url += ('&'+encodeURIComponent(param)+'='+encodeURIComponent(me.signParams[param]()));
+             } else {
+               url += ('&'+encodeURIComponent(param)+'='+encodeURIComponent(me.signParams[param]));
+             }
            }
+
+          for ( var header in me.signHeaders ) {
+            if (!me.signHeader.hasOwnProperty(header)) {continue;}
+            if( me.signHeaders[header] instanceof Function ) {
+              xhr.setRequestHeader(header, me.signHeaders[header]())
+            } else {
+              xhr.setRequestHeader(header, me.signHeaders[header])
+            }
+          }
 
            xhr.onreadystatechange = function(){
 

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -56,6 +56,10 @@
                     },
                     fooHeader: 'bar'
                   },
+                  beforeSigner: function(xhr) {
+                    var requestDate = (new Date()).toISOString();
+                    xhr.setRequestHeader('Request-Header', requestDate);
+                  },
                   complete: function(){
                      console.log('complete................yay!');
                   },

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -45,7 +45,16 @@
                      'x-amz-acl': 'public-read'
                   },
                   signParams: {
-                     foo: 'bar'
+                     foo: 'bar',
+                     fooFunction: function() {
+                       return 'bar';
+                     }
+                  },
+                  signHeaders: {
+                    fooHeaderFunction: function() {
+                      return 'bar'
+                    },
+                    fooHeader: 'bar'
                   },
                   complete: function(){
                      console.log('complete................yay!');


### PR DESCRIPTION
My server has a very robust authentication and verification process.  Every call to our server needs to be MD5 hashed and signed properly for authentication and verification to pass.  In order to do this I need to be able to set headers on the signer call and I need to be able to then hash and sign the entire signer request before it is sent to the server.  I have made three changes that should allow users to use more secure authentication and verification processes, such as HMAC, to authorize the signer request.

1) I added the 'signHeaders' property to add function options.  This property works like the 'signParams' property.  It takes an object of key/value pairs and uses those to set headers on the signer request.

2)  I enhanced both the 'signHeaders' and 'signParams' properties to accept functions as the value property of the key value pair.  This allows for dynamic creation of these properties if they need to be dynamic for each individual signer request.

3)  I added a callback to the add function options named 'beforeSigner'  this call back will pass a reference of the xhr request to the callback right before it sends the signer request.  This allows the developer using EvaporateJS to modify the signer request in any way they need to before it is sent to server.  This is where I can get all of the data in the signer request and create the proper signature for the server to authenticate and verify the signer request.