### PR TITLE
add a link to how to work with temporary credentials in Amazon EC2 instances blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,7 @@ The `supported` property is _Boolean_, and indicates whether the browser has the
 ## Integration
 
 * [angular-evaporate](https://github.com/uqee/angular-evaporate) &mdash; AngularJS module.
+
+## Working with temporary credentials in Amazon EC2 instances
+
+* [Security and S3 Multipart Upload](http://www.thoughtworks.com/mingle/infrastructure/2015/06/15/security-and-s3-multipart-upload.html)


### PR DESCRIPTION
Hi,

I'm not sure what's right place to put this blog post link, so just append it to the end of readme file.
You can change it as you need.

This pull request is a follow of https://github.com/TTLabs/EvaporateJS/issues/76.

We worked out a final solution for working with temporary credentials in Amazon EC2 instances and write a blog post about it, so want to share with you.
