### PR TITLE
Issue 96: Adds Support for AWS Content-MD5 Request Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ So far the api contains just two methods, and one property
 * **logging**: default=true, whether EvaporateJS outputs to the console.log  - should be `true` or `false`
 * **maxConcurrentParts**: default=5, how many concurrent file PUTs will be attempted
 * **partSize**: default = 6 * 1024 * 1024 bytes, the size of the parts into which the file is broken
-* **retryBackoffPower**: default=2, how aggresively to back-off on the delay between retries of a part PUT
+* **retryBackoffPower**: default=2, how aggressively to back-off on the delay between retries of a part PUT
 * **maxRetryBackoffSecs**: default=20, the maximum number of seconds to wait between retries 
 * **progressIntervalMS**: default=1000, the frequency (in milliseconds) at which progress events are dispatched
 * **aws_url**: default='https://s3.amazonaws.com', the S3 endpoint URL

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This is an beta release. It still needs lots more work and testing, but we do us
 
      <script language="javascript" type="text/javascript" src="../evaporate.js"></script>
 
+2. If you want to compute an MD5 digest for AWS, then make sure to include your preferred javascript
+cryptography library that supports creating an MD5 digest for the Content-MD5 request header as
+specified [here](https://www.ietf.org/rfc/rfc1864.txt). The following library provides support:
+
+     - [Spark MD5](https://github.com/satazor/SparkMD5)
+
 2. Setup your S3 bucket, make sure your CORS settings for your S3 bucket looks similar to what is provided below (The PUT allowed method and the ETag exposed header are critical).
 
         <CORSConfiguration>
@@ -92,6 +98,10 @@ So far the api contains just two methods, and one property
 * **aws_url**: default='https://s3.amazonaws.com', the S3 endpoint URL
 * **cloudfront**: default=false, whether to format upload urls to upload via CloudFront. Usually requires aws_url to be something other than the default
 * **timeUrl',**: default=undefined, a url on your application server which will return a DateTime. for example '/sign_auth/time' and return a RF 2616 Date (http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html) e.g. "Tue, 01 Jan 2013 04:39:43 GMT".  See https://github.com/TTLabs/EvaporateJS/issues/74
+* **computeContentMd5',**: default=false, whether to compute and send an MD5 digest for each part for verification by AWS S3.,
+* **cryptoMd5Method',**: default=undefined, a method that computes the MD5 digest according to https://www.ietf.org/rfc/rfc1864.txt. Only applicable when `computeContentMd5` is set.
+    Method signature is `function (data) { return 'computed MD5 digest of data'; }` where `data` is a JavaScript binary string representation of the body payload to encode. If you are using:
+    - Spark MD5, the method would look like this: `function (data) { return btoa(SparkMD5.hashBinary(data, true)); }`.
 
 ### .add()
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -463,7 +463,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
         function computePartMd5Digest(part) {
            return function () {
-              var s = me.file.status;
+              var s = me.status;
               if (s == ERROR || s == CANCELED) {
                  return;
               }

--- a/evaporate.js
+++ b/evaporate.js
@@ -17,7 +17,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 *  version 0.0.2                                                                                  *
 *                                                                                                  *
 *  TODO:                                                                                           *
-*       calculate MD5s and send with PUTs                                                          *
 *       post eTags to application server to allow resumability after client-side crash/restart      *
 *                                                                                                  *
 *                                                                                                  *
@@ -518,11 +517,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               return;
            }
 
-           parts.forEach(function(part,i){
-
-              var requiresUpload = false;
-              stati.push(part.status);
-              if (part){
+           for (var i = 0; i < parts.length; i++) {
+              var part = parts[i];
+              if (part) {
+                 if (con.computeContentMd5 && part.md5_digest === null) {
+                    return; // MD5 Digest isn't ready yet
+                 }
+                 stati.push(part.status);
                  switch(part.status){
 
                     case EVAPORATING:
@@ -552,7 +553,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                     }
                  }
               }
-           });
+           }
 
 
            info = stati.toString() + ' // bytesLoaded: ' + bytesLoaded.toString();

--- a/evaporate.js
+++ b/evaporate.js
@@ -295,6 +295,17 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            );
            l.d('uploadPart #' + partNumber + '     will wait ' + backOff + 'ms to try');
 
+           function getAwsResponse(xhr) {
+              var oParser = new DOMParser(),
+                  oDOM = oParser.parseFromString(xhr.responseText, "text/xml"),
+                  code = oDOM.getElementsByTagName("Code"),
+                  msg = oDOM.getElementsByTagName("Message");
+              code = code.length ? code[0].innerHTML : '';
+              msg = msg.length ? msg[0].innerHTML : '';
+
+              return code.length ? {code: code, msg: msg} : {};
+           }
+
            upload = {
               method: 'PUT',
               path: getPath() + '?partNumber='+partNumber+'&uploadId='+me.uploadId,
@@ -328,10 +339,14 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               } else {
                  part.status = ERROR;
                  part.loadedBytes = 0;
+
+                 awsResponse = getAwsResponse(xhr);
+                 if (awsResponse.code) {
+                    l.e('AWS Server response: code="' + awsResponse.code + '", message="' + awsResponse.msg + '"');
+                 }
                  processPartsList();
               }
               xhr.abort();
-              // TODO: does AWS have other error codes that we can handle?
            };
 
            upload.on200 = function (xhr){

--- a/evaporate.js
+++ b/evaporate.js
@@ -351,12 +351,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               part.loadedBytes = evt.loaded;
            };
 
-           var slicerFn = (me.file.slice ? 'slice' : (me.file.mozSlice ? 'mozSlice' : 'webkitSlice'));
-           // browsers' implementation of the Blob.slice function has been renamed a couple of times, and the meaning of the 2nd parameter changed. For example Gecko went from slice(start,length) -> mozSlice(start, end) -> slice(start, end). As of 12/12/12, it seems that the unified 'slice' is the best bet, hence it being first in the list. See https://developer.mozilla.org/en-US/docs/DOM/Blob for more info.
-
            upload.toSend = function() {
-              var slice= me.file[slicerFn](part.start, part.end);
-              l.d('sending part # ' + partNumber + ' (bytes ' + part.start + ' -> ' + part.end + ')  reported length: ' + slice.size);
+              var slice = getFilePart(me.file, part.start, part.end);
+              l.d('part # ' + partNumber + ' (bytes ' + part.start + ' -> ' + part.end + ')  reported length: ' + slice.size);
               if(!part.isEmpty && slice.size === 0) // issue #58
               {
                  l.w('  *** WARN: blob reporting size of 0 bytes. Will try upload anyway..');
@@ -775,6 +772,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
      }
 
   };
+
+   function getFilePart(file, start, end) {
+      var slicerFn = (file.slice ? 'slice' : (file.mozSlice ? 'mozSlice' : 'webkitSlice'));
+      // browsers' implementation of the Blob.slice function has been renamed a couple of times, and the meaning of the 2nd parameter changed. For example Gecko went from slice(start,length) -> mozSlice(start, end) -> slice(start, end). As of 12/12/12, it seems that the unified 'slice' is the best bet, hence it being first in the list. See https://developer.mozilla.org/en-US/docs/DOM/Blob for more info.
+      return file[slicerFn](start, end);
+   }
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = Evaporate;

--- a/evaporate.js
+++ b/evaporate.js
@@ -538,6 +538,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  if (con.computeContentMd5 && part.md5_digest === null) {
                     return; // MD5 Digest isn't ready yet
                  }
+                 var requiresUpload = false;
                  stati.push(part.status);
                  switch(part.status){
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -51,9 +51,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         maxRetryBackoffSecs: 300,
         progressIntervalMS: 500,
         cloudfront: false,
-        encodeFilename: true
+        encodeFilename: true,
+        computeContentMd5: false
 
      }, config);
+     if (con.computeContentMd5) {
+        if (typeof con.cryptoMd5Method !== 'function') {
+           alert('Option computeContentMd5 has been set but cryptoMd5Method is not defined.');
+           return;
+        }
+     }
 
      //con.simulateStalling =  true
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -237,6 +237,14 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
         function initiateUpload(){ // see: http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadInitiate.html
 
+           function processFileParts() {
+              if (con.computeContentMd5 && me.file.size > 0) {
+                 processPartsListWithMd5Digests();
+              } else {
+                 processPartsList();
+              }
+           }
+
            var initiate = {
               method: 'POST',
               path: getPath() + '?uploads',
@@ -261,7 +269,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  me.uploadId = match[1];
                  l.d('requester success. got uploadId ' + me.uploadId);
                  makeParts();
-                 processPartsList();
+                 processFileParts();
               }else{
                  initiate.onErr();
               }
@@ -293,9 +301,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               path: getPath() + '?partNumber='+partNumber+'&uploadId='+me.uploadId,
               step: 'upload #' + partNumber,
               x_amz_headers: me.xAmzHeadersAtUpload,
+              md5_digest: part.md5_digest,
               attempts: part.attempts
            };
-           // TODO: add md5
 
            upload.onErr = function (xhr, isOnError){
 
@@ -493,6 +501,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  attempts: 0,
                  loadedBytes: 0,
                  loadedBytesPrevious: null,
+                 md5_digest: null,
+                 part: part,
                  isEmpty: (me.file.size === 0) // issue #58
               };
            }

--- a/evaporate.js
+++ b/evaporate.js
@@ -681,6 +681,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  xhr.setRequestHeader('Content-Type', requester.contentType);
               }
 
+              if (requester.md5_digest) {
+                 xhr.setRequestHeader('Content-MD5', requester.md5_digest);
+              }
               xhr.onreadystatechange = function(){
 
                  if (xhr.readyState == 4){
@@ -789,7 +792,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
            to_sign = request.method+'\n'+
-              '\n'+
+              (request.md5_digest || '')+'\n'+
               (request.contentType || '')+'\n'+
               '\n'+
               x_amz_headers +

--- a/evaporate.js
+++ b/evaporate.js
@@ -602,7 +602,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         /*
            Issue #6 identified that some parts would stall silently.
            The issue was only noted on Safari on OSX. A bug was filed with Apple, #16136393
-           This function was addeded as a work-around. It check the progress of each part every 2 minutes.
+           This function was added as a work-around. It checks the progress of each part every 2 minutes.
            If it finds a part that has made no progress in the last 2 minutes then it aborts it. It will then be detected as an error, and restarted in the same manner of any other errored part
         */
         function monitorPartsProgress(){


### PR DESCRIPTION
This pull request adds support for MD5 digest transmission to AWS and addresses https://github.com/TTLabs/EvaporateJS/issues/96.

Notes: The choice of cryptographic MD5 digest implementation is pluggable in this branch. I tried several implementations but settled on Spark MD5. Instructions on how to get this JavaScript library are in the README changes.

This branch uses 2 new configuration options: `computeContentMd5` is already used in the AWS JavaScript for Browsers SDK, so I chose that name for consistency. To make the checksum method pluggable, developers can define that method with the `cryptoMd5Method`.

Note that on initialization, if `computeContentMd5`, then the code uses `alert()` if `cryptoMd5Method` is not defined as a function. Clearly this is harsh but could be considered necessary so that later indeterminate behavior can be avoided.

The way this works is to use a FileReader object. To get the contents of the object so that we can create the MD5 digest requires an asynchronous call where the digest is completed in the callback. I tried to make minimal changes to the existing code to enable better review.

This pull request also reads the AWS response object, parsed the XML and replies in the upload's on onerror callback.