### PR TITLE
Issue 98: Adds support for AWS Multipart Abort

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -767,6 +767,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         return obj1;
      }
 
+     function parseXml(body) {
+        var parser = new DOMParser();
+        return parser.parseFromString(body, "text/xml");
+     }
+
   };
 
   if (typeof module !== 'undefined' && module.exports) {

--- a/evaporate.js
+++ b/evaporate.js
@@ -222,9 +222,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         function cancelAllRequests(){
            l.d('cancelAllRequests()');
 
-           xhrs.forEach(function(xhr,i){
-              xhr.abort();
-           });
+           for (var i = 1; i < parts.length; i++) {
+              abortPart(i);
+           }
 
            abortUpload();
         }

--- a/evaporate.js
+++ b/evaporate.js
@@ -441,7 +441,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            var abort = {
               method: 'DELETE',
               path: getPath() + '?uploadId=' + me.uploadId,
-              step: 'abort'
+              step: 'abort',
+              successStatus: 204
            };
 
            abort.onErr = function () {
@@ -665,6 +666,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               var payload = requester.toSend ? requester.toSend() : null;
               var url = AWS_URL + requester.path;
               var all_headers = {};
+              var status_success = requester.successStatus || 200;
               extend(all_headers, requester.not_signed_headers);
               extend(all_headers, requester.x_amz_headers);
 
@@ -691,7 +693,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  if (xhr.readyState == 4){
 
                     if(payload){l.d('  ### ' + payload.size);} // Test, per http://code.google.com/p/chromium/issues/detail?id=167111#c20
-                    if (xhr.status == 200  || xhr.status == 204){
+                    if (xhr.status == status_success) {
                        requester.on200(xhr);
                     } else {
                        requester.onErr(xhr);

--- a/evaporate.js
+++ b/evaporate.js
@@ -225,6 +225,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            xhrs.forEach(function(xhr,i){
               xhr.abort();
            });
+
+           abortUpload();
         }
 
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -628,7 +628,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                  if (xhr.readyState == 4){
 
                     if(payload){l.d('  ### ' + payload.size);} // Test, per http://code.google.com/p/chromium/issues/detail?id=167111#c20
-                    if (xhr.status == 200){
+                    if (xhr.status == 200  || xhr.status == 204){
                        requester.on200(xhr);
                     } else {
                        requester.onErr(xhr);

--- a/evaporate.js
+++ b/evaporate.js
@@ -390,9 +390,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            var part = parts[partNumber];
 
            if (part.uploader.awsXhr){
+              part.uploader.awsXhr.onreadystatechange = function () {};
               part.uploader.awsXhr.abort();
            }
            if (part.uploader.authXhr){
+              part.uploader.authXhr.onreadystatechange = function () {};
               part.uploader.authXhr.abort();
            }
         }

--- a/evaporate.js
+++ b/evaporate.js
@@ -310,9 +310,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
                   var errMsg = '404 error resulted in abortion of both this part and the entire file.';
                   l.w(errMsg + ' Server response: ' + xhr.response);
                   me.error(errMsg);
-                  // TODO: kill off other uploading parts when file is aborted
                   part.status = ABORTED;
-                  setStatus(ABORTED);
+                  abortUpload();
               } else {
                  part.status = ERROR;
                  part.loadedBytes = 0;

--- a/evaporate.js
+++ b/evaporate.js
@@ -203,8 +203,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
            l.d('stopping FileUpload ', me.id);
            me.cancelled();
-           me.info('upload canceled');
            setStatus(CANCELED);
+           me.info('Canceling uploads...');
            cancelAllRequests();
         };
 
@@ -473,7 +473,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            list.onErr = function (xhr) {
               if (xhr.status == 404) {
                  // Success! Parts are not found because the uploadid has been cleared
-                 l.d('checkForParts found no parts.')
+                 me.info('upload canceled');
               } else {
                  var msg = 'Error listing parts.';
                  l.w(msg);
@@ -487,6 +487,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
               if (parts.length) { // Some parts are still uploading
                  l.d('Parts still found after abort...waiting.')
                  setTimeout(function () { abortUpload(); }, 1000);
+              } else {
+                 me.info('upload canceled');
               }
            };
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -432,6 +432,66 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            authorizedSend(complete);
         }
 
+        function abortUpload() { //http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadAbort.html
+
+           l.d('abortUpload');
+           me.info('will attempt to abort the upload');
+
+           var abort = {
+              method: 'DELETE',
+              path: getPath() + '?uploadId=' + me.uploadId,
+              step: 'abort'
+           };
+
+           abort.onErr = function () {
+              var msg = 'Error aborting upload.';
+              l.w(msg);
+              me.error(msg);
+           };
+
+           abort.on200 = function () {
+              setStatus(ABORTED);
+              checkForParts();
+           };
+
+           setupRequest(abort);
+           authorizedSend(abort);
+        }
+
+        function checkForParts() { //http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadListParts.html
+
+           l.d('listParts');
+           me.info('list parts');
+
+           var list = {
+              method: 'GET',
+              path: getPath() + '?uploadId=' + me.uploadId,
+              step: 'list'
+           };
+
+           list.onErr = function (xhr) {
+              if (xhr.status == 404) {
+                 // Success! Parts are not found because the uploadid has been cleared
+                 l.d('checkForParts found no parts.')
+              } else {
+                 var msg = 'Error listing parts.';
+                 l.w(msg);
+                 me.error(msg);
+              }
+           };
+
+           list.on200 = function (xhr) {
+              var oDOM = parseXml(xhr.responseText);
+              var parts = oDOM.getElementsByTagName("Part");
+              if (parts.length) { // Some parts are still uploading
+                 l.d('Parts still found after abort...waiting.')
+                 setTimeout(function () { abortUpload(); }, 1000);
+              }
+           };
+
+           setupRequest(list);
+           authorizedSend(list);
+        }
 
         function makeParts(){
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -294,6 +294,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
            upload.onErr = function (xhr, isOnError){
 
+              if (me.status === CANCELED) {
+                 return;
+              }
+
               var msg = 'problem uploading part #' + partNumber + ',   http status: ' + xhr.status +
               ',   hasErrored: ' + !!hasErrored + ',   part status: ' + part.status +
               ',   readyState: ' + xhr.readyState + (isOnError ? ',   isOnError' : '');
@@ -370,10 +374,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
            setupRequest(upload);
 
-           setTimeout(function(){
-              authorizedSend(upload);
-              l.d('upload #',partNumber,upload);
-           },backOff);
+           setTimeout(function () {
+              if (me.status !== ABORTED && me.status !== CANCELED) {
+                 authorizedSend(upload);
+                 l.d('upload #', partNumber, upload);
+              }
+           }, backOff);
 
            part.uploader = upload;
         }

--- a/evaporate.js
+++ b/evaporate.js
@@ -223,7 +223,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            l.d('cancelAllRequests()');
 
            for (var i = 1; i < parts.length; i++) {
-              abortPart(i);
+              abortPart(i, true);
            }
 
            abortUpload();
@@ -384,17 +384,20 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            part.uploader = upload;
         }
 
-
-        function abortPart(partNumber){
+        function abortPart(partNumber, clearReadyStateCallback){
 
            var part = parts[partNumber];
 
            if (part.uploader.awsXhr){
-              part.uploader.awsXhr.onreadystatechange = function () {};
+              if (!!clearReadyStateCallback) {
+                 part.uploader.awsXhr.onreadystatechange = function () {};
+              }
               part.uploader.awsXhr.abort();
            }
            if (part.uploader.authXhr){
-              part.uploader.authXhr.onreadystatechange = function () {};
+              if (!!clearReadyStateCallback) {
+                 part.uploader.authXhr.onreadystatechange = function () {};
+              }
               part.uploader.authXhr.abort();
            }
         }


### PR DESCRIPTION
This pull requests uses the AWS MultiPart Upload Abort and ListParts endpoints to correctly clean up the S3 resources (parts) for any aborted uploads. 

Note that the authorized user for S3 must be enabled for `s3:AbortMultipartUpload` and `s3:ListMultipartUploadParts` actions.

http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadAbort.html and http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html.

This pull request treads a teeny bit on https://github.com/TTLabs/EvaporateJS/pull/97. I can bring this branch current with master if that branch is merged first. 