### PR TITLE
Added url parameter to beforeSigner callback

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -709,7 +709,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
            }
           
            if( me.beforeSigner instanceof Function ) {
-             me.beforeSigner(xhr);
+             me.beforeSigner(xhr, url);
            }
            xhr.send();
         }

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -56,9 +56,10 @@
                     },
                     fooHeader: 'bar'
                   },
-                  beforeSigner: function(xhr) {
+                  beforeSigner: function(xhr, url) {
                     var requestDate = (new Date()).toISOString();
                     xhr.setRequestHeader('Request-Header', requestDate);
+                    console.log('the xhr url is:' + url);
                   },
                   complete: function(){
                      console.log('complete................yay!');

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -17,7 +17,7 @@
       
       <div>
          <input type="file" id="files"  multiple />
-      <div>
+      </div>
             
       
       <script language="javascript">
@@ -27,7 +27,7 @@
          var _e_ = new Evaporate({
             signerUrl: '/sign_auth',
             aws_key: 'your aws_key here',
-            bucket: 'your s3 bucket name here',
+            bucket: 'your s3 bucket name here'
          });
       
          $('#files').change(function(evt){


### PR DESCRIPTION
  I added the url parameter to the beforeSigner callback.  The url is not accessible from the XMLHttpRequest object and the generated query string can be used to create a better authentication between the client and the server before authorizing upload.  This is import for HMAC style authorization schemes.