### PR TITLE
Fix issue when uploading the same file copied in two different locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.3#
+
+## Bug Fixes##
+
+- Fix issue when uploading the same file copied in two different locations. Now EvaporateJS will treat these as different files, and not think they are the same file.
+
 # v1.0.2#
 
 ## Features##

--- a/evaporate.js
+++ b/evaporate.js
@@ -1273,12 +1273,14 @@
 
         function uploadKey(fileUpload) {
             // The key tries to give a signature to a file in the absence of its path.
-            // "<filename>-<mimetype>-<modifieddate>-<filesize>"
+            // Need to include path (if present) in case the same file is present in multiple paths/folders
+            // "<filename>-<mimetype>-<modifieddate>-<filesize>-<path>"
             return [
                 fileUpload.file.name,
                 fileUpload.file.type,
                 dateISOString(fileUpload.file.lastModifiedDate),
-                fileUpload.file.size
+                fileUpload.file.size,
+                fileUpload.name
             ].join("-");
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaporate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Javascript library for browser to S3 multipart resumable uploads",
   "main": "evaporate.js",
   "directories": {


### PR DESCRIPTION
Now EvaporateJS will treat these as different files, and not think they are the same file.