### PR TITLE
Add a note to examples that the request should be authenticated

### DIFF
--- a/example/ServerTimeExample.java
+++ b/example/ServerTimeExample.java
@@ -17,7 +17,7 @@ public class ServerTimeExample extends HttpServlet
 	/**
 	 * Output the date in the RFC 1123, same output from JavaScript new Date().toUTCString()
 	 * In case you don't have or can't add Apache HttpClient library to your project, the pattern is EEE, dd MMM yyyy HH:mm:ss zzz
-	 * 
+	 *
 	 * @param req
 	 * @param resp
 	 * @throws ServletException
@@ -26,6 +26,7 @@ public class ServerTimeExample extends HttpServlet
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException
 	{
+	    // TODO: Do something to authenticate this request
 		resp.getWriter().write(DateUtils.formatDate(new Date()));
 	}
 }

--- a/example/SigningExample.cs
+++ b/example/SigningExample.cs
@@ -14,6 +14,7 @@ public class SigningExampleController : ApiController
     [Route("")]
     public IHttpActionResult Get([FromUri] string to_sign)
     {
+        // TODO: Do something to authenticate this request
         var content = new StringContent(SignData(to_sign));
         content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Text.Plain);
         var response = new HttpResponseMessage(HttpStatusCode.OK) {Content = content};

--- a/example/SigningExample.java
+++ b/example/SigningExample.java
@@ -21,6 +21,7 @@ public class SigningExample extends HttpServlet
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
+        // TODO: Do something to authenticate this request
         String data = request.getParameter("to_sign");
 
         if(StringUtils.isEmpty(data))
@@ -35,9 +36,9 @@ public class SigningExample extends HttpServlet
 
     /**
      * http://docs.aws.amazon.com/AmazonSimpleDB/latest/DeveloperGuide/HMACAuth.html#AuthJavaSampleHMACSignature
-     * 
+     *
      * Computes RFC 2104-compliant HMAC signature.
-     * 
+     *
      * @param data
      *           The data to be signed.
      * @param key

--- a/example/SigningExample.js
+++ b/example/SigningExample.js
@@ -14,6 +14,7 @@ app.use(bodyParser.urlencoded({
 app.listen(8080, '127.0.0.1');
 
 app.use('/sign_auth', function (req, res) {
+	// TODO: Do something to authenticate this request
 	res.send(crypto
 		.createHmac('sha1', env.AWS_SECRET)
 		.update(req.query.to_sign)

--- a/example/signing_example.py
+++ b/example/signing_example.py
@@ -13,6 +13,7 @@ import hmac, sha
 class SignAuth(webapp2.RequestHandler):
 
    def get(self):
+      # TODO: Do something to authenticate this request
       to_sign = str(self.request.get('to_sign'))
       signature = base64.b64encode(hmac.new('YOUR_AWS_SECRET_KEY', to_sign, sha).digest())
       self.response.headers['Content-Type'] = "text/HTML"

--- a/example/signing_example.rb
+++ b/example/signing_example.rb
@@ -19,6 +19,7 @@ end
 # controller
 # -*- encoding : utf-8 -*-
 class PagesController < ApplicationController
+  # TODO: Do something to authenticate this request
   encoded = AuthSign.sign_data(params["to_sign"])
 
   render :text => encoded, :status => 200 and return

--- a/example/signing_example_express.js
+++ b/example/signing_example_express.js
@@ -4,6 +4,7 @@ var express = require('express'),
 var app = express();
 
 app.get('/signer', function (req, res) {
+    // TODO: Do something to authenticate this request
     res.send(
         crypto
             .createHmac('sha1', 'YOUR_AWS_SECRET_KEY')


### PR DESCRIPTION
I have asked people to use this for projects, and they consistently forget/don't realise, that the examples for the server are not copy paste ready because they need some authentication added. I later notice that I can just upload any image from anywhere