### PR TITLE
Removes synchronous timeUrl logic; fetches time once and uses an offset after that

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ So far the api contains just two methods, and one property
 * **partSize**: default = 6 * 1024 * 1024 bytes, the size of the parts into which the file is broken
 * **retryBackoffPower**: default=2, how aggressively to back-off on the delay between retries of a part PUT
 * **maxRetryBackoffSecs**: default=20, the maximum number of seconds to wait between retries 
+* **maxFileSize**: default=no limit, the allowed maximum files size, in bytes.
 * **progressIntervalMS**: default=1000, the frequency (in milliseconds) at which progress events are dispatched
 * **aws_url**: default='https://s3.amazonaws.com', the S3 endpoint URL
 * **cloudfront**: default=false, whether to format upload urls to upload via CloudFront. Usually requires aws_url to be something other than the default
@@ -196,7 +197,9 @@ So far the api contains just two methods, and one property
 * **name**: _String_. the S3 ObjectName that the completed file will have
 * **file**: _File_. a reference to the file object
 
-The `.add()` method returns the internal EvaporateJS id of the upload to process. Use this id to abort or cancel an upload.
+The `.add()` method returns the internal EvaporateJS id of the upload to process. Use this id to abort or cancel
+ an upload. If the file validation passes, this method returns an integer representing the file id, otherwise,
+ it returns a string error message.
 
 `config` has a number of optional parameters:
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -51,6 +51,7 @@
             signHeaders: {},
             awsLambda: null,
             awsLambdaFunction: null,
+            maxFileSize: null,
             // undocumented
             testUnsupported: false,
             simulateStalling: false,
@@ -159,6 +160,9 @@
             var err;
             if (typeof file === 'undefined') {
                 return 'Missing file';
+            }
+            if (con.maxFileSize && file.size > con.maxFileSize) {
+                return 'File size too large. Maximum size allowed is ' + con.maxFileSize;
             }
             if (typeof file.name === 'undefined') {
                 err = 'Missing attribute: name  ';

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -25,9 +25,10 @@
          var files;
          
          var _e_ = new Evaporate({
-            signerUrl: '/sign_auth',
-            aws_key: 'your aws_key here',
-            bucket: 'your s3 bucket name here'
+            signerUrl: 'http://localhost:3000/sign_auth',
+            timeUrl: 'http://localhost:3000/timestamp',
+            aws_key: 'AKIAI35IN4YICFYEONOA',
+            bucket: 'bikeath1337-evaporate'
          });
       
          $('#files').change(function(evt){
@@ -38,29 +39,6 @@
                _e_.add({
                   name: 'test_' + Math.floor(1000000000*Math.random()),
                   file: files[i],
-                  notSignedHeadersAtInitiate: {
-                     'Cache-Control': 'max-age=3600'
-                  },
-                  xAmzHeadersAtInitiate : {
-                     'x-amz-acl': 'public-read'
-                  },
-                  signParams: {
-                     foo: 'bar',
-                     fooFunction: function() {
-                       return 'bar';
-                     }
-                  },
-                  signHeaders: {
-                    fooHeaderFunction: function() {
-                      return 'bar'
-                    },
-                    fooHeader: 'bar'
-                  },
-                  beforeSigner: function(xhr, url) {
-                    var requestDate = (new Date()).toISOString();
-                    xhr.setRequestHeader('Request-Header', requestDate);
-                    console.log('the xhr url is:' + url);
-                  },
                   complete: function(){
                      console.log('complete................yay!');
                   },


### PR DESCRIPTION
Addresses #133 by asynchronously calling the `timeUrl` once at load time, calculating the offset from the current client time and then for each request, just offsetting the client time to reflect the associated server time.

Note: The logic assumes that the timeUrl fetch completes before the first file request is created. Whether this a good assumption, needs to be evaluated.