### PR TITLE
If no me.uploadId is set, don't send abort request

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -692,6 +692,11 @@
                 l.d('abortUpload');
                 me.info('will attempt to abort the upload');
 
+                if(typeof me.uploadId === 'undefined') {
+                    setStatus(ABORTED);
+                    return;
+                }
+
                 var abort = {
                     method: 'DELETE',
                     path: getPath() + '?uploadId=' + me.uploadId,


### PR DESCRIPTION
As discussed in #135 