### PR TITLE
ISSUE-157: Removes Superfluous Option + Adds Ruby Sample V4 Signing Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ using AWS Signature Version 4, this URL must respond with the V4 signing key.
     payload to encode. If you are using:
     - Spark MD5, the method would look like this: `function (data) { return btoa(SparkMD5.ArrayBuffer.hash(data, true)); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.md5(data, 'base64'); }`.
-* **cryptoHmacMethod**: default=undefined, a method that computes the HMAC by using the SHA256 algorithm with the signing key provided. Required when `awsSignatureVersion` is `'4'`.
-    - AWS SDK for JavaScript: `function (signingKey, stringToSign) { return AWS.util.crypto.hmac(signingKey, stringToSign, 'hex'); }`.
 * **cryptoHexEncodedHash256**: default=undefined, a method that computes the lowercase base 16 encoded SHA256 hash. Required when `awsSignatureVersion` is `'4'`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.sha256(data, 'hex'); }`.
 * **s3FileCacheHoursAgo**: default=null (no cache), whether to use the S3 uploaded cache of parts and files for ease of recovering after
@@ -246,7 +244,6 @@ The `.add()` method returns the internal EvaporateJS id of the upload to process
 - `timeUrl`
 - `cryptoMd5Method`
 - `aws_key`
-- `cryptoHmacMethod`
 - `cryptoHexEncodedHash256`
 - `awsRegion`
 - `awsSignatureVersion`
@@ -290,7 +287,7 @@ GET requests. It goes without saying that your AWS IAM credentials and secrets s
 You can use AWS Signature Version 4. The `signerUrl` response must respond with a valid V4 signature. This version of EvaporateJS sends the
 part payload as `UNSIGNED-PAYLOAD` because we enable MD5 checksum calculations.
 
-Be sure to configure EvaporateJS with `aws_key`, `aws_region`, `cryptoHmacMethod` and `cryptoHexEncodedHash256` when enabling Version 4 signatures.
+Be sure to configure EvaporateJS with `aws_key`, `aws_region` and `cryptoHexEncodedHash256` when enabling Version 4 signatures.
 
 [AWS Sginature Version 4](http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html) for more information.
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -36,7 +36,6 @@
             'onlyRetryForSameFileName',
             'timeUrl',
             'cryptoMd5Method',
-            'cryptoHmacMethod',
             'cryptoHexEncodedHash256',
             'aws_key',
             'awsRegion',
@@ -66,7 +65,6 @@
             onlyRetryForSameFileName: false,
             timeUrl: null,
             cryptoMd5Method: null,
-            cryptoHmacMethod: null,
             cryptoHexEncodedHash256: null,
             aws_key: null,
             awsRegion: null,
@@ -125,10 +123,6 @@
             if (con.awsSignatureVersion === '4') {
                 if (typeof con.cryptoHexEncodedHash256 !== 'function') {
                     l.e('Option awsSignatureVersion is 4 but cryptoHexEncodedHash256 is not defined.');
-                    return;
-                }
-                if (typeof con.cryptoHmacMethod !== 'function') {
-                    l.e('Option awsSignatureVersion is 4 but cryptoHmacMethod is not defined.');
                     return;
                 }
             }

--- a/example/evaporate_example_awsv4_signature.html
+++ b/example/evaporate_example_awsv4_signature.html
@@ -33,7 +33,6 @@
       awsSignatureVersion: '4',
       computeContentMd5: true,
       cryptoMd5Method: function (data) { return AWS.util.crypto.md5(data, 'base64'); },
-      cryptoHmacMethod: function (signingKey, stringToSign) { return AWS.util.crypto.hmac(signingKey, stringToSign, 'hex'); },
       cryptoHexEncodedHash256: function (data) { return AWS.util.crypto.sha256(data, 'hex'); }
    });
 

--- a/example/signing_example_awsv4_controller.rb
+++ b/example/signing_example_awsv4_controller.rb
@@ -1,0 +1,35 @@
+# example of how to do the AWS V4 Signature for a Rails app
+
+class Signingv4Controller < ApplicationController
+
+  AWS_SERVICE = 's3'
+  AWS_REGION = 'us-east-1'
+
+  def signv4_auth
+    render text: hmac_data, status: 200
+  end
+
+  def hmac_data
+    aws_secret = Rails.application.secrets.AWS_SECRET || ENV['AWS_SECRET']
+    timestamp = params[:datetime]
+
+    date = hmac("AWS4#{aws_secret}", timestamp[0..7])
+    region = hmac(date, AWS_REGION)
+    service = hmac(region, AWS_SERVICE)
+    signing = hmac(service, 'aws4_request')
+
+
+    hexhmac(signing, params[:to_sign])
+  end
+
+  private
+
+    def hmac(key, value)
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
+    end
+
+    def hexhmac(key, value)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), key, value)
+    end
+
+end


### PR DESCRIPTION
Addresses #157 . The `cryptoHmacMethod` option was not used. Also added sample Ruby on Rails code for a V4 controller generating the signing key.