### PR TITLE
Adds a function for when a file has started

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -281,6 +281,7 @@
 
             var id = files.length;
             files.push(new FileUpload(extend({
+                started: function () {},
                 progress: function () {},
                 complete: function () {},
                 cancelled: function () {},
@@ -341,7 +342,7 @@
 
             me.start = function () {
                 l.d('starting FileUpload ' + me.id);
-
+                me.started();
                 setStatus(EVAPORATING);
 
                 var awsKey = me.name;


### PR DESCRIPTION
There are callbacks for almost every state of the file upload except for when the upload has started. Figured it would be useful to have a `started` function too, particularly if you're uploading multiple files.

This would also help #13 

**started**: _function()_. a function that will be called when the file upload has started.