### PR TITLE
Fix bug causing SignatureDoesNotMatch errors. Closes #185.

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1429,7 +1429,7 @@
 
             function canonicalQueryStringV4(request) {
                 var search = uri(request.path).search,
-                    parts = search.split('&'),
+                    parts = search.length ? search.split('&') : [],
                     encoded = [],
                     nameValue,
                     i;


### PR DESCRIPTION
"".split will return [""] not [].  The knock on effect of this was
an = sign turning up in the payload, and therefore our computed hash
did not match Amazon's hash.