### PR TITLE
Optional signer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ and various configuration options:
 * **signResponseHandler**: default=null, a method that handles the XHR response with the signature. It must return the `base64` encoded signature. If you
     set this option, Evaporate will pass the signature response it received from the `signerUrl` or `awsLambda` methods to your `signResponseHandler`.
     The method signature is `function (response) { return 'computed signature'; }`.
+* **skipSignerRequest**: default=false, set to true to skip authorizing the requests with Evaporate's mechanism. Instead, provide a **signResponseHandler** method that will return a signature in any way you might need. If set to true, you can pass an empty string to **signerUrl**.
 
 #### Evaporate#add()
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -80,6 +80,7 @@
             maxFileSize: null,
             signResponseHandler: null,
             xhrWithCredentials: false,
+            skipSignerRequest: false,
             // undocumented
             testUnsupported: false,
             simulateStalling: false,
@@ -1352,9 +1353,19 @@
                     };
             }
 
+            // skip Evaporate's signing request
+            // see issue #197 https://git.io/v6Aa2
+            function skipAuthorizedSend(authRequester) {
+              authRequester.auth = signResponse();
+              authRequester.onGotAuth();
+            }
 
             //see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/RESTAuthentication.html#ConstructingTheAuthenticationHeader
             function authorizedSend(authRequester) {
+                if (con.skipSignerRequest) {
+                  skipAuthorizedSend(authRequester)
+                  return;
+                }
 
                 l.d('authorizedSend() ' + authRequester.step);
                 if (hasCurrentXhr(authRequester)) {


### PR DESCRIPTION
Would you be interested in something like this @bikeath1337? I am getting back to my last request from #197.

Basically we already have our own custom backend for generating signatures and also code that deals with getting the proper signature. We have to do these "signer" requests before "evaporating" anyway. So the fact that Evaporate is doing it in `authorizedSend` method is getting in the way. I've added a parameter that enables users to skip this mechanism and provide the signatures from `signResponseHandler` instead. I also added a line to README documenting that.

What do you think?

Closes #197.