### PR TITLE
Resets the number of bytes uploaded earlier for when a part upload Fails

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -604,6 +604,8 @@
                 };
 
                 upload.onErr = function (xhr, isOnError) {
+                    part.loadedBytes = 0;
+
                     removePartFromProcessing(part);
 
                     if ([CANCELED, ABORTED, PAUSED, PAUSING].indexOf(me.status) > -1) {
@@ -630,7 +632,6 @@
                         abortUpload();
                     } else {
                         part.status = ERROR;
-                        part.loadedBytes = 0;
 
                         var awsResponse = getAwsResponse(xhr);
                         if (awsResponse.code) {


### PR DESCRIPTION
The first time a part failed did not reset the total bytes uploaded for the part. Addresses #209.