### PR TITLE
Fix pathname bug causing signature mismatches in IE

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1773,7 +1773,8 @@
         return {
             protocol: p.protocol, // => "http:"
             hostname: p.hostname, // => "example.com"
-            pathname: p.pathname, // => "/pathname/"
+            // IE omits the leading slash, so add it if it's missing
+            pathname: p.pathname.replace(/(^\/?)/,"/"), // => "/pathname/"
             port: p.port, // => "3000"
             search: (p.search[0] === '?') ? p.search.substr(1) : p.search, // => "search=test"
             hash: p.hash, // => "#hash"


### PR DESCRIPTION
IE omits the leading slash from `pathname`, so check for the expected leading slash and add it if it's missing.