### PR TITLE
Allow parentheses in filenames

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -370,7 +370,7 @@
             var fileParts = fileName.split('/'),
                 encodedParts = [];
             fileParts.forEach(function (p) {
-                encodedParts.push(encodeURIComponent(p));
+                encodedParts.push(encodeURIComponent(p).replace(/\(/g, "%28").replace(/\)/g, "%29"));
             });
             return encodedParts.join('/');
         }


### PR DESCRIPTION
`encodeURIComponent()` does not encode parentheses, but AWS do, and so we get
a signature mismatch.  This commit adds a manual conversion of
parentheses to their corresponding URL encodings.