### PR TITLE
Provide the stringToSign to signResponseHandler

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1375,14 +1375,9 @@
                     return authorizedSignWithLambda(authRequester);
                 }
 
-                if (typeof con.signerUrl === 'undefined') {
-                    authRequester.auth = signResponse();
-                    authRequester.onGotAuth();
-                    return;
-                }
-
                 var xhr = assignCurrentXhr(authRequester),
-                    url = [con.signerUrl, '?to_sign=', stringToSignMethod(authRequester), '&datetime=', authRequester.dateString].join('');
+                    stringToSign = stringToSignMethod(authRequester),
+                    url = [con.signerUrl, '?to_sign=', stringToSign, '&datetime=', authRequester.dateString].join('');
 
                 var signParams = makeSignParamsObject(me.signParams);
                 for (var param in signParams) {
@@ -1392,6 +1387,13 @@
 
                 if (con.xhrWithCredentials) {
                     xhr.withCredentials = true;
+                }
+
+                if (typeof con.signerUrl === 'undefined') {
+                    authRequester.auth = signResponse(null, stringToSign);
+                    clearCurrentXhr(authRequester);
+                    authRequester.onGotAuth();
+                    return;
                 }
 
                 xhr.onreadystatechange = function () {
@@ -1469,9 +1471,9 @@
                 return encodeURIComponent(con.awsSignatureVersion === '4' ? stringToSignV4(request) : makeStringToSign(request));
             }
 
-            function signResponse(payload) {
+            function signResponse(payload, stringToSign) {
                 if (typeof con.signResponseHandler === 'function') {
-                    payload = con.signResponseHandler(payload) || payload;
+                    payload = con.signResponseHandler(payload, stringToSign) || payload;
                 }
 
                 return payload;


### PR DESCRIPTION
This is a follow up to commit 8f2e791caee446a05a01a8f4b6878dfeb1442a86 where we introduced the ability to skip signing requests with Evaporate in favor of `signResponseHandler` when provided and `signerUrl` being `undefined`.

I realized that in order to actually correctly sign the request that I am about to sign I need that `request` body. That's inside the `url` variable inside `?to_sign=` url parameter.

Without this change, it is possible to re-create the request that's being signed. In order to sign it, we'd also need the `timeUrl` to be correct. However, the implementation is not very nice and having the `url` or even better only the `stringToSignMethod(authRequester)` would be awesome.