### PR TITLE
Addresses Retry Issues and Cooperative Processing of Parts

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -713,6 +713,7 @@
                     me.warn(msg.join(" "));
                     part.status = ERROR;
                     part.loadedBytes = 0;
+                    removePartFromProcessing(partNumber);
                     processPartsAsync();
                 };
 
@@ -724,16 +725,20 @@
 
                 setTimeout(function () {
                     if ([ABORTED, PAUSED, CANCELED].indexOf(me.status) === -1) {
-                        part.status = EVAPORATING;
-                        part.attempts += 1;
-                        part.loadedBytesPrevious = null;
+                        if (partsInProcess.indexOf(part.part) === -1) {
+                            console.log('uploadPart #', partNumber, 'kicking off');
 
-                        countUploadAttempts += 1;
+                            part.status = EVAPORATING;
+                            part.attempts += 1;
+                            part.loadedBytesPrevious = null;
 
-                        clearCurrentXhr(upload);
-                        addPartToProcessing(part);
-                        authorizedSend(upload);
-                        l.d('upload #', partNumber, upload);
+                            countUploadAttempts += 1;
+
+                            clearCurrentXhr(upload);
+                            addPartToProcessing(part);
+                            authorizedSend(upload);
+                            l.d('upload #', partNumber, upload);
+                        }
                     }
                 }, backOff);
 
@@ -1434,7 +1439,6 @@
                 }
 
                 xhr.onreadystatechange = function () {
-
                     if (xhr.readyState === 4) {
 
                         var calledFrom = "readyState===4";
@@ -1450,7 +1454,7 @@
                               authRequester.onGotAuth();
                             }
                         } else {
-                            xhr.onerror(calledFrom)
+                            xhr.onerror(calledFrom);
                         }
                     }
                 };

--- a/evaporate.js
+++ b/evaporate.js
@@ -950,7 +950,7 @@
             function getUploadParts(partNumberMarker) { //http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadListParts.html
 
                 var msg = ['getUploadParts() for uploadId starting at part #', partNumberMarker];
-                l.d.apply(null, msg);
+                l.d(msg);
                 me.info(msg.join(" "));
 
                 var list = {

--- a/evaporate.js
+++ b/evaporate.js
@@ -707,7 +707,7 @@
                     return slice;
                 };
 
-                upload.onFailedAuth = function () {
+                upload.onFailedAuth = function (xhr) {
                     var msg = ['onFailedAuth for uploadPart #', partNumber, '- Will set status to ERROR'];
                     l.w(msg);
                     me.warn(msg.join(" "));
@@ -905,9 +905,6 @@
                             createUploadFile();
                             processPartsAsync();
                         }
-                    } else {
-                        // Resumed
-                        processPartsAsync();
                     }
                 }
                 if (completed === s3Parts.length) {
@@ -1173,13 +1170,11 @@
             }
 
             function processPartsAsync() {
-                setTimeout(function () {
-                    if (s3Parts.length - 1 === partsOnS3.length) {
-                        completeUpload();
-                    } else {
-                        processPartsList();
-                    }
-                }, 100);
+                if (s3Parts.length - 1 === partsOnS3.length) {
+                    completeUpload();
+                } else {
+                    processPartsList();
+                }
             }
 
             function processPartsList() {

--- a/evaporate.js
+++ b/evaporate.js
@@ -1,4 +1,4 @@
-/*Copyright (c) 2014, TT Labs, Inc.
+/*Copyright (c) 2016, TT Labs, Inc.
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -594,7 +594,6 @@
                 var backOff, hasErrored, upload, part;
 
                 part = s3Parts[partNumber];
-                part.status = EVAPORATING;
                 countUploadAttempts++;
                 part.loadedBytesPrevious = null;
 
@@ -698,11 +697,10 @@
 
                 setTimeout(function () {
                     if (evaporatingCount < con.maxConcurrentParts && [ABORTED, PAUSED, CANCELED].indexOf(me.status) === -1) {
+                        part.status = EVAPORATING;
                         addPartToProcessing(part);
                         authorizedSend(upload);
                         l.d('upload #', partNumber, upload);
-                    } else {
-                        part.status = PENDING;
                     }
                 }, backOff);
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -1223,13 +1223,8 @@ l.e('NOT UPLOADING PART!!!!')
 
                         var part = s3Parts[partIdx],
                             healthy;
-                        if (part.status !== EVAPORATING) {
-                            l.d(partIdx, 'not evaporating ');
-                            return;
-                        }
 
                         if (part.loadedBytesPrevious === null) {
-                            l.d(partIdx,'no previous ');
                             part.loadedBytesPrevious = part.loadedBytes;
                             return;
                         }

--- a/evaporate.js
+++ b/evaporate.js
@@ -611,8 +611,6 @@
                 upload.onErr = function (xhr, isOnError) {
                     part.loadedBytes = 0;
 
-                    removePartFromProcessing(part);
-
                     if ([CANCELED, ABORTED, PAUSED, PAUSING].indexOf(me.status) > -1) {
                         return;
                     }
@@ -630,6 +628,8 @@
                     hasErrored = true;
 
                     if (xhr.status === 404) {
+                        removePartFromProcessing(part);
+
                         var errMsg = '404 error resulted in abortion of both this part and the entire file.';
                         l.w(errMsg + ' Server response: ' + xhr.response);
                         me.error(errMsg);

--- a/evaporate.js
+++ b/evaporate.js
@@ -1169,7 +1169,7 @@
 
             function processPartsAsync() {
                 setTimeout(function () {
-                    if (s3Parts.length -1 === partsOnS3.length) {
+                    if (s3Parts.length - 1 === partsOnS3.length) {
                         completeUpload();
                     } else {
                         processPartsList();

--- a/evaporate.js
+++ b/evaporate.js
@@ -565,6 +565,8 @@
 
                     xhr.abort();
 
+                    clearCurrentXhr(initiate);
+
                     setTimeout(function () {
                         if (me.status !== ABORTED && me.status !== CANCELED) {
                             me.status = originalStatus;
@@ -645,15 +647,19 @@
                             l.e('AWS Server response: code="' + awsResponse.code + '", message="' + awsResponse.msg + '"');
                         }
 
-                        removePartFromProcessing(part);
-                        processPartsList();
+                        xhr.abort();
+
+                        clearCurrentXhr(upload);
+
+                        removePartFromProcessing(part.part);
+                        setTimeout(processPartsList, 100);
 
                         if (hasErrored) {
                             return;
                         }
                         hasErrored = true;
                     }
-                    xhr.abort();
+
                 };
 
                 upload.on200 = function (xhr) {
@@ -1234,6 +1240,9 @@
                             setTimeout(function () {
                                 me.info('part #' + partIdx, ' stalled. will abort.', part.loadedBytesPrevious, part.loadedBytes);
                                 abortPart(partIdx);
+                                part.status = PENDING;
+                                removePartFromProcessing(partIdx);
+                                setTimeout(processPartsList, 100);
                             },0);
                         }
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -695,6 +695,8 @@
                         addPartToProcessing(part);
                         authorizedSend(upload);
                         l.d('upload #', partNumber, upload);
+                    } else {
+                        part.status = PENDING;
                     }
                 }, backOff);
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -1150,7 +1150,6 @@
                     limit = con.maxConcurrentParts - evaporatingCount;
 
                 if (limit === 0) {
-                    l.d('No slots available to upload.')
                     return;
                 }
                 if (me.status !== EVAPORATING) {
@@ -1172,7 +1171,6 @@
                     }
                     limit -= 1;
                     if (limit === 0) {
-                        l.e('break limit === 0')
                         break;
                     }
                 }

--- a/evaporate.js
+++ b/evaporate.js
@@ -717,8 +717,6 @@
                     processPartsAsync();
                 };
 
-                setupRequest(upload);
-
                 backOff = backOffWait(part.attempts);
                 l.d('uploadPart #', partNumber, '- will wait', backOff, 'ms before',
                     part.attempts === 0 ? 'submitting' : 'retrying');
@@ -733,6 +731,8 @@
                             part.loadedBytesPrevious = null;
 
                             countUploadAttempts += 1;
+
+                            setupRequest(upload);
 
                             clearCurrentXhr(upload);
                             addPartToProcessing(part);

--- a/evaporate.js
+++ b/evaporate.js
@@ -677,6 +677,7 @@
                         part.eTag = eTag;
                         part.status = COMPLETE;
 
+                        partsOnS3.push(part);
                         retirePartFromProcessing(part);
                     } else {
                         part.status = ERROR;
@@ -1162,7 +1163,13 @@
             }
 
             function processPartsAsync() {
-                setTimeout(processPartsList, 100);
+                setTimeout(function () {
+                    if (s3Parts.length -1 === partsOnS3.length) {
+                        completeUpload();
+                    } else {
+                        processPartsList();
+                    }
+                }, 100);
             }
 
             function processPartsList() {
@@ -1200,10 +1207,6 @@
 
                 if (countUploadAttempts >= (s3Parts.length - 1)) {
                     me.info('part stati:', info);
-                }
-
-                if (partsToUpload.length === 0) {
-                    completeUpload();
                 }
             }
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -656,7 +656,7 @@
 
                         if (!isOnError) {
                             removePartFromProcessing(part.part);
-                            setTimeout(processPartsList, 100);
+                            processPartsAsync();
                         }
 
                         if (hasErrored) {
@@ -685,7 +685,7 @@
                         l.w(msg);
                         me.warn(msg.join(" "));
                     }
-                    setTimeout(processPartsList, 100);
+                    processPartsAsync();
                 };
 
                 upload.onProgress = function (evt) {
@@ -707,7 +707,7 @@
                     me.warn(msg.join(" "));
                     part.status = ERROR;
                     part.loadedBytes = 0;
-                    setTimeout(processPartsList, 100);
+                    processPartsAsync();
                 };
 
                 setupRequest(upload);
@@ -867,7 +867,7 @@
                     numDigestsProcessed += 1;
 
                     if (evaporatingCount < con.maxConcurrentParts) {
-                        setTimeout(processPartsList, 100);
+                        processPartsAsync();
                     }
 
                     if (numDigestsProcessed === numParts) {
@@ -897,7 +897,7 @@
                         } else { // We already calculated the first part's md5_digest
                             part.md5_digest = me.firstMd5Digest;
                             createUploadFile();
-                            setTimeout(processPartsList, 100);
+                            processPartsAsync();
                         }
                     }
                 }
@@ -1004,7 +1004,7 @@
                         removeUploadFile();
                         monitorProgress();
                         makeParts();
-                        setTimeout(processPartsList, 100);
+                        processPartsAsync();
                     } else {
                         var msg = 'Error listing parts for getUploadParts() starting at part # ' + partNumberMarker;
                         l.w(msg, getAwsResponse(xhr));
@@ -1161,6 +1161,10 @@
                 );
             }
 
+            function processPartsAsync() {
+                setTimeout(processPartsList, 100);
+            }
+
             function processPartsList() {
                 var stati = [], bytesLoaded = [],
                     limit = con.maxConcurrentParts - evaporatingCount;
@@ -1256,7 +1260,7 @@
                                 abortPart(partIdx);
                                 part.status = PENDING;
                                 removePartFromProcessing(partIdx);
-                                setTimeout(processPartsList, 100);
+                                processPartsAsync();
                             },0);
                         }
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -1401,12 +1401,12 @@ l.e('NOT UPLOADING PART!!!!')
                         if (xhr.status === 200) {
                             var payload = signResponse(xhr.response);
 
+                            clearCurrentXhr(authRequester);
                             if (con.awsSignatureVersion === '2' &&  payload.length !== 28) {
-                                warnMsg(calledFrom, true);
+                                warnMsg(calledFrom);
                             } else {
                               l.d('authorizedSend got signature for step:', authRequester.step, '- signature:', payload);
                               authRequester.auth = payload;
-                              clearCurrentXhr(authRequester);
                               authRequester.onGotAuth();
                             }
                         } else {
@@ -1416,7 +1416,7 @@ l.e('NOT UPLOADING PART!!!!')
                 };
 
                 xhr.onerror = function (msg) {
-                    warnMsg(msg || 'onerror', false);
+                    warnMsg(msg || 'onerror');
                 };
 
                 xhr.open('GET', url);
@@ -1431,13 +1431,10 @@ l.e('NOT UPLOADING PART!!!!')
                 }
                 xhr.send();
 
-                function warnMsg(srcMsg, clearXhr) {
+                function warnMsg(srcMsg) {
                     var a = ['failed to get authorization (', srcMsg, ') for', authRequester.step, '-  xhr.status:', xhr.status, '.-  xhr.response:', xhr.response];
                     l.w(a);
                     me.warn(a.join(" "));
-                    if (clearXhr) {
-                        clearCurrentXhr(authRequester, true);
-                    }
                     authRequester.onFailedAuth(xhr);
                 }
             }

--- a/evaporate.js
+++ b/evaporate.js
@@ -480,8 +480,12 @@
 
             function removePartFromProcessing(part) {
                 removeAtIndex(partsInProcess, part.part);
-                removeAtIndex(partsToUpload, part.part);
                 evaporatingCnt(-1);
+            }
+
+            function retirePartFromProcessing(part) {
+                removeAtIndex(partsToUpload, part.part);
+                removePartFromProcessing(part);
                 if (partsInProcess.length === 0 && me.status === PAUSING) {
                     me.status = PAUSED;
                     me.paused();
@@ -628,7 +632,7 @@
                     hasErrored = true;
 
                     if (xhr.status === 404) {
-                        removePartFromProcessing(part);
+                        retirePartFromProcessing(part);
 
                         var errMsg = '404 error resulted in abortion of both this part and the entire file.';
                         l.w(errMsg + ' Server response: ' + xhr.response);
@@ -655,7 +659,7 @@
                         part.eTag = eTag;
                         part.status = COMPLETE;
 
-                        removePartFromProcessing(part);
+                        retirePartFromProcessing(part);
                     } else {
                         part.status = ERROR;
                         part.loadedBytes = 0;

--- a/evaporate.js
+++ b/evaporate.js
@@ -1207,21 +1207,15 @@
                     }
                 }
 
-                var monitorPartsInterval = 0;
                 if (!bytesLoaded.length) {
                     // we're probably offline or in a very bad state
                     l.w('processPartsList() No bytes loaded for any parts. We may be offline.')
                     if (partsMonitorInterval === PARTS_MONITOR_INTERVALS.online) {
-                        monitorPartsInterval = PARTS_MONITOR_INTERVALS.offline;
+                        partsMonitorInterval = PARTS_MONITOR_INTERVALS.offline;
                     }
                 } else if (partsMonitorInterval === PARTS_MONITOR_INTERVALS.offline) {
                     l.d('processPartsList() Back online.')
-                    monitorPartsInterval = PARTS_MONITOR_INTERVALS.online;
-                }
-
-                if (monitorPartsInterval) {
-                    partsMonitorInterval = monitorPartsInterval;
-                    monitorPartsProgress();
+                    partsMonitorInterval = PARTS_MONITOR_INTERVALS.online;
                 }
 
                 var info = stati.toString() + ' // bytesLoaded: ' + bytesLoaded.toString();


### PR DESCRIPTION
This pull request should address all known issues with part processing: error handling when on and offline, and should address #227.

One improvement is that Evaporate tries to detect when the browser is offline. It adjusts it's parts monitor interval to 20 seconds in such a case.

The reason parts were failing inexplicably was that Evaporate was sending more than one PUT request for the same part.

@jakubzitny @fkjaekel 