### PR TITLE
Prevents Safari console.log.apply from throwing error.

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -950,7 +950,7 @@
             function getUploadParts(partNumberMarker) { //http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadListParts.html
 
                 var msg = ['getUploadParts() for uploadId starting at part #', partNumberMarker];
-                l.d.apply(null, msg);
+                l.d(msg[0], msg[1]);
                 me.info(msg.join(" "));
 
                 var list = {


### PR DESCRIPTION
Since Safari doesn't supports console.log.apply(null, ['arg1', 'arg2...']) and only works with console.log.apply(console, ['arg1', 'arg2']) it used to throw an error if logging was enabled causing files not to be uploaded.