### PR TITLE
Addresses Issues Identified When Creating Test Coverage

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1011,7 +1011,7 @@
                         makeParts();
                         processPartsToUpload();
                     } else {
-                        var msg = 'Error listing parts for getUploadParts() starting at part # ' + partNumberMarker;
+                        var msg = 'Error listing parts for getUploadParts() starting at part # ' + (partNumberMarker + 1);
                         l.w(msg, getAwsResponse(xhr));
                         me.error(msg);
                     }

--- a/evaporate.js
+++ b/evaporate.js
@@ -577,8 +577,6 @@
                     me.warn('Error initiating upload', getAwsResponse(xhr));
                     setStatus(ERROR);
 
-                    xhr.abort();
-
                     clearCurrentXhr(initiate);
 
                     setTimeout(function () {
@@ -655,8 +653,6 @@
                         if (awsResponse.code) {
                             l.e('AWS Server response: code="' + awsResponse.code + '", message="' + awsResponse.msg + '"');
                         }
-
-                        xhr.abort();
 
                         clearCurrentXhr(upload);
 
@@ -795,8 +791,6 @@
                     l.w(msg, getAwsResponse(xhr));
                     me.error(msg);
                     setStatus(ERROR);
-
-                    xhr.abort();
 
                     setTimeout(function () {
                         if (me.status !== ABORTED && me.status !== CANCELED) {
@@ -1856,8 +1850,8 @@
             oDOM = oParser.parseFromString(xhr.responseText, "text/html"),
             code = oDOM.getElementsByTagName("Code"),
             msg = oDOM.getElementsByTagName("Message");
-        code = code && code.length ? code[0].innerHTML : '';
-        msg = msg && msg.length ? msg[0].innerHTML : '';
+        code = code && code.length ? (code[0].innerHTML || code[0].textContent) : '';
+        msg = msg && msg.length ? (msg[0].innerHTML || msg[0].textContent) : '';
 
         return code.length ? {code: code, msg: msg} : {};
     }

--- a/evaporate.js
+++ b/evaporate.js
@@ -25,7 +25,7 @@
 
     var Evaporate = function (config) {
 
-        var PENDING = 0, EVAPORATING = 2, COMPLETE = 3, PAUSED = 4, CANCELED = 5, ERROR = 10, ABORTED = 20, PAUSING = 30, ETAG_OF_0_LENGTH_BLOB = '"d41d8cd98f00b204e9800998ecf8427e"';
+        var PENDING = 0, EVAPORATING = 2, COMPLETE = 3, PAUSED = 4, CANCELED = 5, ERROR = 10, ABORTED = 20, PAUSING = 30, COMPLETING = 40, ETAG_OF_0_LENGTH_BLOB = '"d41d8cd98f00b204e9800998ecf8427e"';
         var IMMUTABLE_OPTIONS = [
             'maxConcurrentParts',
             'logging',
@@ -1171,7 +1171,10 @@
 
             function processPartsToUpload() {
                 if (numParts === partsOnS3.length) {
-                    completeUpload();
+                    if ([COMPLETE, COMPLETING].indexOf(me.status) === -1) {
+                        me.status = COMPLETING;
+                        completeUpload();
+                    }
                     return;
                 }
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -431,7 +431,7 @@
                     initiateUpload(awsKey);
                 } else {
                     if (typeof me.eTag === 'undefined' || !me.firstMd5Digest || !con.computeContentMd5) {
-                        if (fileTotalBytesUploaded > 0) {
+                        if (partsOnS3.length) {
                             startFileProcessing(false);
                         } else {
                             // File with some parts on S3

--- a/evaporate.js
+++ b/evaporate.js
@@ -430,7 +430,7 @@
                     // New File
                     initiateUpload(awsKey);
                 } else {
-                    if (typeof me.eTag === 'undefined' || !me.firstMd5Digest) {
+                    if (typeof me.eTag === 'undefined' || !me.firstMd5Digest || !con.computeContentMd5) {
                         if (fileTotalBytesUploaded > 0) {
                             startFileProcessing(false);
                         } else {

--- a/evaporate.js
+++ b/evaporate.js
@@ -991,8 +991,6 @@
                 l.d(msg);
                 me.info(msg);
 
-                partsOnS3 = [];
-
                 var list = {
                     method: 'GET',
                     path: getPath() + '?uploadId=' + me.uploadId,

--- a/evaporate.js
+++ b/evaporate.js
@@ -415,6 +415,11 @@
             me.start = function () {
                 l.d('starting FileUpload', me.id);
                 me.started(me.id);
+
+                if (me.status === ABORTED) {
+                  return;
+                }
+
                 setStatus(EVAPORATING);
 
                 var awsKey = me.name;

--- a/test/requests.spec.js
+++ b/test/requests.spec.js
@@ -404,7 +404,7 @@ test.serial.failing('should Start, friendly Pause and Resume an upload', async (
   expect(t.context.config.paused.callCount).to.equal(1)
   expect(t.context.config.resumed.callCount).to.equal(1)
 
-  expect(t.context.request_order).to.equal('initiate,PUT:partNumber=1,check for parts,PUT:partNumber=2,complete')
+  expect(t.context.request_order).to.equal('initiate,PUT:partNumber=1,PUT:partNumber=2,complete')
   expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
 })
 
@@ -417,7 +417,7 @@ test.serial.failing('should Start, force Pause and Resume an upload', async (t) 
   expect(t.context.config.paused.callCount).to.equal(1)
   expect(t.context.config.resumed.callCount).to.equal(1)
 
-  expect(t.context.request_order).to.equal('initiate,PUT:partNumber=1,check for parts,PUT:partNumber=2,complete')
+  expect(t.context.request_order).to.equal('initiate,PUT:partNumber=1,PUT:partNumber=2,complete')
   expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
 })
 

--- a/test/retry.spec.js
+++ b/test/retry.spec.js
@@ -1,0 +1,519 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import test from 'ava'
+
+import Evaporate from '../evaporate'
+
+import initResponse from './fixtures/init-response'
+import completeResponse from './fixtures/complete-response'
+import getPartsResponse from './fixtures/get-parts-truncated-response'
+
+
+// constants
+
+const CONTENT_TYPE_XML = { 'Content-Type': 'text/xml' }
+const CONTENT_TYPE_TEXT = { 'Content-Type': 'text/plain' }
+
+const AWS_BUCKET = 'bucket'
+const AWS_UPLOAD_KEY = 'tests'
+
+const baseConfig = {
+  signerUrl: 'http://what.ever/sign',
+  aws_key: 'testkey',
+  bucket: AWS_BUCKET,
+  logging: false,
+  maxRetryBackoffSecs: 0.1,
+  abortCompletionThrottlingMs: 0,
+  progressIntervalMS: 5
+}
+
+const baseAddConfig = {
+  name: AWS_UPLOAD_KEY,
+  file: new File({
+    path: '/tmp/file',
+    size: 50,
+    name: 'tests'
+  })
+}
+
+let server,
+    requestMap = {
+      'GET:to_sign': 'sign',
+      'POST:uploads': 'initiate',
+      'POST:uploadId': 'complete',
+      'DELETE:uploadId': 'cancel',
+      'GET:uploadId': 'check for parts'
+    },
+    headersForMethod,
+    headStatus
+
+function randomAwsKey() {
+  return Math.random().toString().substr(2) + '_' + AWS_UPLOAD_KEY
+}
+
+test.before(() => {
+  sinon.xhr.supportsCORS = true
+  global.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
+  global.window = {
+    localStorage: {},
+    console: console
+  };
+})
+
+test.beforeEach((t) => {
+  t.context.requestedAwsObjectKey = randomAwsKey()
+
+  t.context.baseAddConfig = {
+    name: t.context.requestedAwsObjectKey,
+    file: new File({
+      path: '/tmp/file',
+      size: 6000000,
+      name: randomAwsKey()
+    })
+  }
+
+  t.context.cryptoMd5 = sinon.spy(function (data) { return 'md5Checksum'; })
+
+  headStatus = 200
+  server = sinon.fakeServer.create({
+    respondImmediately: true
+  })
+
+  headersForMethod = function(method, urlRegex) {
+    var r = urlRegex || /./
+    for (var i = 0; i < server.requests.length; i++) {
+      var xhr = server.requests[i]
+      if (xhr.method === method && xhr.url.match(r)) {
+        return xhr.requestHeaders
+      }
+    }
+    return {}
+  }
+
+  t.context.testBase = async function (addConfig, evapConfig) {
+    t.context.deferred = defer();
+
+    t.context.evaporate = new Evaporate(Object.assign({}, baseConfig,
+        {cryptoMd5Method: t.context.cryptoMd5}, evapConfig))
+
+    if (typeof addConfig.started === "function") {
+      addConfig.user_started = addConfig.started;
+      delete addConfig.started;
+    }
+
+    if (typeof addConfig.complete === "function") {
+      addConfig.user_complete = addConfig.complete;
+      delete addConfig.complete;
+    }
+
+    t.context.config = Object.assign({}, t.context.baseAddConfig, addConfig, {
+      started: sinon.spy(function (id) {
+        t.context.uploadId = id;
+        if (typeof addConfig.user_started === "function")  {
+          addConfig.user_started(id);
+        }
+      }),
+      complete: sinon.spy(function (xhr, awsKey) {
+        t.context.completedAwsKey = awsKey;
+        if (typeof addConfig.user_complete === "function")  {
+          addConfig.user_complete(xhr, awsKey);
+        }
+        t.context.deferred.resolve();
+      })
+    })
+
+    t.context.evaporate.add(t.context.config)
+
+    await t.context.deferred.promise
+
+  }
+
+  t.context.request_order = function () {
+    var request_order = []
+    server.requests.forEach(function (r) {
+      var x = r.url.split('?'),
+          y = x[1] ? x[1].split('&') : '',
+          z = y[0] ? y[0].split('=')[0] : y
+      if (z === 'partNumber') {
+        z += '='
+        z += y[0].split('=')[1]
+      }
+
+      var v = z ? r.method + ':' + z : r.method
+      request_order.push(requestMap[v] || v)
+    })
+
+    return request_order.join(',')
+  }
+
+  t.context.testCommon = async function (addConfig, evapConfig) {
+    if (!t.context.putResponseSet) {
+      t.context.putResponseSet = true
+    }
+    await t.context.testBase(addConfig, evapConfig)
+  }
+
+  t.context.testPauseResume = async function (evapConfig) {
+    server.respondWith('PUT', /^.*$/, (xhr) => {
+      if (xhr.url.indexOf('partNumber=1') > -1) {
+        t.context.pause();
+      }
+      xhr.respond(200)
+    })
+
+    server.respondWith('GET', /.*\?uploadId.*$/, (xhr) => {
+      xhr.respond(200, CONTENT_TYPE_XML, getPartsResponse(AWS_BUCKET, AWS_UPLOAD_KEY, 0, 0))
+    })
+
+    const config = {
+      name: t.context.requestedAwsObjectKey,
+      file: new File({
+        path: '/tmp/file',
+        size: 12000000,
+        name: randomAwsKey()
+      }),
+      started: sinon.spy(function () { }),
+      pausing: sinon.spy(function () { }),
+      paused: sinon.spy(function () {
+        t.context.resume();
+      }),
+      resumed: sinon.spy(function () {})
+    }
+
+    await t.context.testBase(config, evapConfig)
+  }
+
+  t.context.testCachedParts = async function (addConfig, maxGetParts, partNumberMarker, l) {
+    const evapConfig = {
+      s3FileCacheHoursAgo: 24
+    }
+
+    await t.context.testCommon(addConfig, evapConfig)
+
+    partNumberMarker = 0
+
+    await t.context.testCommon(addConfig, evapConfig)
+  }
+
+  t.context.testS3Reuse = async function (addConfig2, evapConfig2) {
+    let evapConfig = Object.assign({}, baseConfig, {
+      allowS3ExistenceOptimization: true,
+      s3FileCacheHoursAgo: 24,
+      computeContentMd5: true
+    })
+
+    // Upload the first time
+    await t.context.testCommon({}, evapConfig)
+
+    addConfig2.name = randomAwsKey()
+
+    // Upload the second time to trigger head
+    evapConfig = Object.assign({}, evapConfig, evapConfig2 || {})
+    await t.context.testCommon(addConfig2, evapConfig)
+
+    t.context.requestedAwsObjectKey = addConfig2.name
+  }
+
+  t.context.pause = function (force) {
+    t.context.evaporate.pause(t.context.uploadId, force)
+  }
+
+  t.context.cancel = function () {
+    t.context.evaporate.cancel(t.context.uploadId)
+  }
+
+  t.context.resume = function () {
+    t.context.evaporate.resume(t.context.uploadId)
+  }
+
+  t.context.resolve = function () {
+    t.context.deferred.resolve()
+  }
+})
+
+test.afterEach(() => {
+  server.restore()
+})
+
+// Retry get authorization / Initiate Upload
+test.serial('should retry get signature for common case: Initiate, Put, Complete (authorization)', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+
+      const payload = Array(29).join()
+      xhr.respond(status, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+
+  await t.context.testCommon({})
+
+  expect(t.context.cryptoMd5.callCount).to.equal(0)
+  expect(t.context.request_order()).to.equal('sign,sign,initiate,sign,sign,PUT:partNumber=1,sign,sign,complete')
+})
+
+// Retry Initiate Upload
+test.serial('should retry Initiate', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+
+    xhr.respond(status, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+
+  await t.context.testCommon({})
+
+  expect(t.context.cryptoMd5.callCount).to.equal(0)
+  expect(t.context.request_order()).to.equal('sign,initiate,sign,initiate,sign,PUT:partNumber=1,sign,complete')
+})
+
+// Retry Complete Upload
+test.serial('should retry Complete', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+    xhr.respond(status, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+
+  await t.context.testCommon({})
+
+  expect(t.context.cryptoMd5.callCount).to.equal(0)
+  expect(t.context.request_order()).to.equal('sign,initiate,sign,PUT:partNumber=1,sign,complete,sign,complete')
+})
+
+// Retry PUT Upload
+test.serial('should retry Upload Part', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+    var errResponse = `
+    <?xml version="1.0" encoding="UTF-8"?>
+      <Error>
+        <Code>NoSuchKey</Code>
+        <Message>The resource you requested does not exist</Message>
+        <Resource>/mybucket/myfoto.jpg</Resource> 
+        <RequestId>4442587FB7D0A2F9</RequestId>
+      </Error>`
+
+    xhr.respond(status, CONTENT_TYPE_XML, status === 200 ? '' : errResponse)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+
+  await t.context.testCommon({})
+
+  expect(t.context.cryptoMd5.callCount).to.equal(0)
+  expect(t.context.request_order()).to.equal('sign,initiate,sign,PUT:partNumber=1,sign,PUT:partNumber=1,sign,complete')
+})
+
+// Cancel
+test.serial.failing('should not retry Cancel but trigger Initiate', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('DELETE', /.*\?uploadId.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 204
+      attempts = 0
+    } else {
+      status = 403
+    }
+    xhr.respond(status)
+  })
+
+
+  const config = {
+    started: sinon.spy(function () { }),
+    cancelled: sinon.spy(function () {
+      t.context.resolve();
+    }),
+    error: sinon.spy(function (msg) {
+      t.context.resolve();
+    })
+  }
+
+  await t.context.testBase(config)
+
+  t.context.deferred = defer();
+
+  t.context.cancel()
+
+  await t.context.deferred.promise
+
+  expect(t.context.config.started.callCount).to.equal(1)
+  expect(t.context.config.cancelled.callCount).to.equal(0)
+  expect(t.context.request_order()).to.equal('sign,initiate,sign,PUT:partNumber=1,sign,complete,sign,cancel')
+})
+
+// HeadObject
+test.serial('should not retry DELETE when trying to reuse S3 object', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+  let headEtag = '"b2969107bdcfc6aa30892ee0867ebe79-1"';
+  server.respondWith('HEAD', /./, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+    xhr.respond(status, {eTag: headEtag}, '')
+  })
+
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  await t.context.testS3Reuse({})
+
+  expect(t.context.config.complete.callCount).to.equal(1)
+  expect(t.context.request_order()).to.equal(
+      'sign,initiate,sign,PUT:partNumber=1,sign,complete,sign,HEAD,' +
+      'sign,initiate,sign,PUT:partNumber=1,sign,complete')
+  expect(t.context.completedAwsKey).to.not.equal(t.context.requestedAwsObjectKey)
+})
+
+// Cached Parts
+test.serial('should not retry check for parts', async (t) => {
+  let maxRetries = 1, attempts = 0, status
+
+  server.respondWith('GET', /.*\?uploadId.*$/, (xhr) => {
+    attempts += 1
+    if (attempts > maxRetries) {
+      status = 200
+      attempts = 0
+    } else {
+      status = 403
+    }
+    xhr.respond(status, CONTENT_TYPE_XML, getPartsResponse(AWS_BUCKET, AWS_UPLOAD_KEY, 1, 0))
+
+  })
+
+  server.respondWith('GET', /\/sign.*$/, (xhr) => {
+    const payload = Array(29).join()
+    xhr.respond(200, CONTENT_TYPE_TEXT, payload)
+  })
+
+  server.respondWith('POST', /^.*\?uploads.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, initResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  server.respondWith('PUT', /^.*$/, (xhr) => {
+    xhr.respond(200)
+  })
+
+  server.respondWith('POST', /.*\?uploadId.*$/, (xhr) => {
+    xhr.respond(200, CONTENT_TYPE_XML, completeResponse(AWS_BUCKET, AWS_UPLOAD_KEY))
+  })
+
+  await t.context.testCachedParts({error: function (m) { t.context.resolve(); }}, 1, 0)
+
+  expect(t.context.request_order()).to.equal('sign,initiate,sign,PUT:partNumber=1,sign,complete,sign,check for parts')
+})
+
+


### PR DESCRIPTION
When creating the test coverage in #256, several unreproted issues were discovered. This PR adds coverage for them and applies the necessary fixes in advance of more refactoring to simplify the code and apply a Promise paradigm.

The issues are:

- the warn message regarding the partNumberMarker was not offset by 1, which it should be, to reference the correct part.
- if .start() was called on an aborted file, the aborted file was processed anyway, but should have been ignored.
- if a user tried to upload no files, then `complete` was never triggered.
- reported uploaded bytes doubled after resuming a partially uploaded file (the number of fully uploaded parts sizes were duplicated).
- reusing an uploaded S3 object should only have been abled if `computeConentMd5` is enabled.
- if the user paused and resumed an upload, internal state was maintained but not used. This has been addressed.
- Adds safety checks to the parser of the AWS error code
- Fetching uploaded parts for upload optimization did not correctly fetch truncated responses, effectively limiting it's usability to files with 1,000 uploaded parts. This has been fixed.