### PR TITLE
Correctly calculate localTimeOffset

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -235,7 +235,7 @@
                     if (xhr.status === 200) {
                         var server_date = new Date(Date.parse(xhr.responseText)),
                             now = new Date();
-                        localTimeOffset = now - server_date;
+                        localTimeOffset = server_date - now;
                         l.d('localTimeOffset is', localTimeOffset, 'ms');
                     }
                 }


### PR DESCRIPTION
As it stands, the localTimeOffset is applied by addition, resulting in the time slippage being doubled when sent in request header.

i) Consider Server time 15:19 and machine clock time 12:19, now - server_date  = -3 Then when applied 12:19 + (-3) = 09:19
ii) The Inverse also holds true, consider Server time 12:19 and machine clock time 15:19, now - server_date  = +3, When applied 15:19 + (+3) = 18:19

With this change both cases after applying the offset would give the server time. 