### PR TITLE
Addresses case where adding a file didn't start the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.0.1
+
+## Bug Fixes ##
+- Issue #277. It was possible for a queued file to not start if the previous file was canceled
+  before it had started. Also addressed edge cases and race conditions when canceling a list
+  of files that have been submitted. Thanks to @cvnfor the test cases.
+
 # v2.0.0
 
 ## New Features ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug Fixes ##
 - Issue #277. It was possible for a queued file to not start if the previous file was canceled
   before it had started. Also addressed edge cases and race conditions when canceling a list
-  of files that have been submitted. Thanks to @cvnfor the test cases.
+  of files that have been submitted. Thanks to @cvn for the test cases.
 
 # v2.0.0
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "evaporatejs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Javascript library for browser to S3 multipart resumable uploads",
   "main": "evaporate.js",
   "keywords": [

--- a/evaporate.js
+++ b/evaporate.js
@@ -189,6 +189,7 @@
         }
     };
     Evaporate.prototype.fileCleanup = function (fileUpload) {
+        removeAtIndex(this.queuedFiles, fileUpload);
         if (removeAtIndex(this.filesInProcess, fileUpload)) {
             this.evaporatingCnt(-1);
         }

--- a/evaporate.js
+++ b/evaporate.js
@@ -492,7 +492,7 @@
         return stats;
     };
     FileUpload.prototype.onProgress = function () {
-        if ([CANCELED, ABORTED, PAUSED].indexOf(this.status) === -1) {
+        if ([ABORTED, PAUSED].indexOf(this.status) === -1) {
             this.progress(this.fileTotalBytesUploaded / this.sizeBytes, this.progessStats());
             this.loaded = 0;
         }
@@ -800,7 +800,7 @@
             return true;
         } else {
             part.status = ERROR;
-            putRequest.resetLoadedBytes(0);
+            putRequest.resetLoadedBytes();
             var msg = ['eTag matches MD5 of 0 length blob for part #', putRequest.partNumber, 'Retrying part.'].join(" ");
             l.w(msg);
             this.warn(msg);
@@ -1446,9 +1446,9 @@
             }
         }
     };
-    PutPart.prototype.resetLoadedBytes = function (v) {
-        this.fileUpload.updateLoaded(0);
-        this.part.loadedBytes = v;
+    PutPart.prototype.resetLoadedBytes = function () {
+        this.fileUpload.updateLoaded(-this.part.loadedBytes);
+        this.part.loadedBytes = 0;
         this.fileUpload.onProgress();
     };
     PutPart.prototype.errorExceptionStatus = function () {
@@ -1477,7 +1477,7 @@
             this.awsDeferred.reject(errMsg);
             return true;
         }
-        this.resetLoadedBytes(0);
+        this.resetLoadedBytes();
         this.part.status = ERROR;
 
         if (!this.errorExceptionStatus()) {
@@ -1489,7 +1489,7 @@
         if (this.currentXhr) {
             this.currentXhr.abort();
         }
-        this.resetLoadedBytes(0);
+        this.resetLoadedBytes();
         this.attempts = 1;
     };
     PutPart.size = 0;

--- a/example/app.yaml
+++ b/example/app.yaml
@@ -1,5 +1,5 @@
 application: evaporatejs
-version: evaporate-200
+version: evaporate-201
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evaporate",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Javascript library for browser to S3 multipart resumable uploads",
   "main": "evaporate.js",
   "directories": {


### PR DESCRIPTION
Addresses #276. Files weren't starting after a canceled file if the canceled file had not started and there was nothing left to upload when that file was canceled. The fix was to removed the non-started file from the queuedFiles list.