### PR TITLE
Enhancements and Improved Payload Calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Otherwise, include it in your HTML:
 ## Example
 
 ```javascript
-require('aws-sdk');
+require('crypto');
 
 var config = {
      signerUrl: <SIGNER_URL>,
@@ -82,7 +82,7 @@ var config = {
      bucket: <AWS_BUCKET>,
      cloudfront: true,
      computeContentMd5: true,
-     cryptoMd5Method: function (data) { return AWS.util.crypto.md5(data, 'base64'); }
+     cryptoMd5Method: function (data) { function (data) { return crypto.createHash('md5').update(data).digest('base64'); }
 };
 
 return Evaporate.create(config)
@@ -366,8 +366,10 @@ Available configuration options:
     Method signature is `function (data) { return 'computed MD5 digest of data'; }` where `data` is a JavaScript `ArrayBuffer` representation of the part
     payload to encode. If you are using:
     - Spark MD5, the method would look like this: `function (data) { return btoa(SparkMD5.ArrayBuffer.hash(data, true)); }`.
+    - Node.js: `function (data) { return crypto.createHash('md5').update(data).digest('base64'); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.md5(data, 'base64'); }`.
 * **cryptoHexEncodedHash256**: default=undefined, a method that computes the lowercase base 16 encoded SHA256 hash. Required when `awsSignatureVersion` is `'4'`.
+    - Node.js: `function (data) { return crypto.createHash('sha256').update(data).digest('hex'); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.sha256(data, 'hex'); }`.
 * **s3FileCacheHoursAgo**: default=null (no cache), whether to use the S3 uploaded cache of parts and files for ease of recovering after
     client failure or page refresh. The value should be a whole number representing the number of hours ago to check for uploaded parts

--- a/evaporate.js
+++ b/evaporate.js
@@ -1382,7 +1382,7 @@
                 self.fileUpload.updateUploadFile({firstMd5Digest: md5_digest})
               }
               resolve(md5_digest);
-            });
+            }, reject);
       } else {
         resolve(part.md5_digest);
       }
@@ -1506,7 +1506,7 @@
       this.payloadFromBlob().then(function (data) {
         this.payload = data;
         resolve(data);
-      }.bind(this));
+      }.bind(this), reject);
     }.bind(this));
   };
   PutPart.prototype.payloadFromBlob = function () {
@@ -1520,7 +1520,8 @@
     return new Promise(function (resolve) {
       var reader = new FileReader();
       reader.onloadend = function () {
-        var data = new Uint8Array(new DataView(this.result).buffer);
+        var result = this.result || new Uint8Array().buffer;
+        var data = new Uint8Array(new DataView(result).buffer);
         resolve(data);
       };
       reader.readAsArrayBuffer(blob);

--- a/evaporate.js
+++ b/evaporate.js
@@ -1368,7 +1368,10 @@
       if (self.con.computeContentMd5 && !part.md5_digest) {
         reader.onloadend = function () {
           reader = undefined;
-          var md5_digest = self.con.cryptoMd5Method(this.result);
+          // DataView uses the address of the result
+          // Uint8Array maps same space as unisigned int for binary upload
+          var data = new Uint8Array(new DataView(this.result).buffer);
+          var md5_digest = self.con.cryptoMd5Method(data);
           if (self.partNumber === 1 && self.con.computeContentMd5 && typeof self.fileUpload.firstMd5Digest === "undefined") {
             self.fileUpload.firstMd5Digest = md5_digest;
             self.fileUpload.updateUploadFile({firstMd5Digest: md5_digest})

--- a/evaporate.js
+++ b/evaporate.js
@@ -1346,7 +1346,7 @@
 
     this.partNumber = part.part;
     this.start = (this.partNumber - 1) * fileUpload.con.partSize;
-    this.end = this.partNumber * fileUpload.con.partSize;
+    this.end = Math.min(this.partNumber * fileUpload.con.partSize, fileUpload.sizeBytes);
 
     var request = {
       method: 'PUT',


### PR DESCRIPTION
- Uses Uint8Array when dealing with ArrayBuffers since a plain old ArrayBuffer is deprecated.
- Optimizes the size of the last uploaded part to be no longer than what is required, not the entire part size
- Refactors how payloads are calculated and used
- Lazily calls getPayload for signing AWS Signature V4 requests