### PR TITLE
Fix python example

### DIFF
--- a/example/app.yaml
+++ b/example/app.yaml
@@ -5,6 +5,9 @@ api_version: 1
 threadsafe: true
 
 handlers:
+- url: /assets
+  static_dir: assets
+
 - url: /
   static_files: evaporate_example.html
   upload: evaporate_example.html
@@ -14,7 +17,7 @@ handlers:
   upload: evaporate_example_lambda.html
 
 - url: /sign_auth
-  script: signing_example.app
+  script: awsv4_signing_example.app
 
 - url: /evaporate\.js
   static_files: ../evaporate.js

--- a/example/evaporate_example.html
+++ b/example/evaporate_example.html
@@ -41,7 +41,7 @@
    // Change these to reflect your local settings
    var AWS_KEY = 'AWS KEY',
            AWS_BUCKET = 's3 bucket name',
-           SIGNER_URL = 'http://localhost:3000/sign_auth';
+           SIGNER_URL = 'http://localhost:8080/sign_auth';
 
    $("#awsKey").text(AWS_KEY);
    $("#s3Bucket").text(AWS_BUCKET);


### PR DESCRIPTION
Defaults to V4 signing script as that the default AWS Sig Version of the library is V4. Also fixed loading of static assets.