### PR TITLE
Enhances signerUrl and customAuthMethod to Include AWS V4 Canonical Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Available configuration options:
 * **signerUrl**: a url on your application server which will sign the request according to your chosen AWS signature method (Version 2 or 4). For example
     'http://myserver.com/auth_upload'. When using AWS Signature Version 4, this URL must respond with the V4 signing key. If you don't want to use
     a signerURL and want to sign the request yourself, then you sign the request using `signResponseHandler`.
+* **sendCanonicalRequestToSignerUrl**: default=false, whether to send the AWS Signature V4 canonical request as a pameter
+    to signerUrl. If enabled, the canonical request will be present in the request as `canonical_request`.
 * **customAuthMethod**: a method that returns an implementation of
     [Promises/A+](http://promises-aplus.github.com/promises-spec/). The promise resolves with the AWS object key of the
     uploaded object. The method is passed the signParams, signHeaders, calculated string to sign and the datetime used

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Available configuration options:
     For example:
 
     ```javascript
-    function (signParams, signHeaders, stringToSign, signatureDateTime) { // pluggable signing
+    function (signParams, signHeaders, stringToSign, signatureDateTime, canonicalRequest) { // pluggable signing
         return new Promise(function (resolve, reject) {
             resolve('computed signature');
         }

--- a/README.md
+++ b/README.md
@@ -228,15 +228,16 @@ var promise = Evaporate.create({
 });
 ```
 
-3. Set your AWS Secret Key in example/signing_example.py
+3. Set your AWS Secret Key in
+   [example/awsv4_signing_example.py](https://github.com/TTLabs/EvaporateJS/blob/master/example/awsv4_signing_example.py)
+   if you are using the [V4 signature signing process](http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+   The `example` folder includes sample code for the [V2 signature signing process](http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html)
+   as well as examples in other languages.
 
-```python
-def get(self):
-   to_sign = str(self.request.get('to_sign'))
-   signature = base64.b64encode(hmac.new('YOUR_AWS_SECRET_KEY', to_sign, sha).digest())
-   self.response.headers['Content-Type'] = "text/HTML"
-   self.response.out.write(signature)
-```
+   NOTE: When AWS responds with `The request signature we calculated does not match the signature you provided. Check your key and signing method`,
+   you have not correctly signed the request. For help with creating a signing method,
+   the best forum for help would be [stackoverflow](http://stackoverflow.com/search?q=multipart+upload+signature) or
+   [AWS Support](https://aws.amazon.com/premiumsupport/).
 
 4. Run it! (From root of Evaporate directory). and visit 'http://localhost:8080/'
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -1672,10 +1672,12 @@
     AwsSignatureV2.prototype.getPayload = function () { return Promise.resolve(); };
 
     function AwsSignatureV4(request) {
+      this._cr = undefined
       AwsSignature.call(this, request);
     }
     AwsSignatureV4.prototype = Object.create(AwsSignature.prototype);
     AwsSignatureV4.prototype.constructor = AwsSignatureV4;
+    AwsSignatureV4.prototype._cr = undefined;
     AwsSignatureV4.prototype.payload = null;
     AwsSignatureV4.prototype.getPayload = function () {
       return awsRequest.getPayload()
@@ -1812,6 +1814,10 @@
       };
     };
     AwsSignatureV4.prototype.canonicalRequest = function () {
+      if (typeof this._cr !== 'undefined') {
+        console.log('Reusing canonical request:', this._cr);
+        return this._cr;
+      }
       var canonParts = [];
 
       canonParts.push(this.request.method);
@@ -1823,9 +1829,9 @@
       canonParts.push(headers.signedHeaders);
       canonParts.push(this.getPayloadSha256Content());
 
-      var result = canonParts.join("\n");
-      l.d(this.request.step, 'V4 CanonicalRequest:', result);
-      return result;
+      this._cr = canonParts.join("\n");
+      l.d(this.request.step, 'V4 CanonicalRequest:', this._cr);
+      return this._cr;
     };
     AwsSignatureV4.prototype.setHeaders = function (xhr) {
       xhr.setRequestHeader("x-amz-content-sha256", this.getPayloadSha256Content());

--- a/evaporate.js
+++ b/evaporate.js
@@ -70,6 +70,7 @@
       aws_key: null,
       awsRegion: 'us-east-1',
       awsSignatureVersion: '4',
+      sendCanonicalRequestToSignerUrl: false,
       s3FileCacheHoursAgo: null, // Must be a whole number of hours. Will be interpreted as negative (hours in the past).
       signParams: {},
       signHeaders: {},
@@ -1045,6 +1046,7 @@
       return;
     }
 
+    this.signer.error();
     l.d(this.request.step, 'error:', this.fileUpload.id, reason);
 
     if (typeof this.errorHandler(reason) !== 'undefined' ) {
@@ -1072,6 +1074,9 @@
   SignedS3AWSRequest.prototype.stringToSign = function () {
     return encodeURIComponent(this.signer.stringToSign());
   };
+  SignedS3AWSRequest.prototype.canonicalRequest = function () {
+    return this.signer.canonicalRequest();
+  }
   SignedS3AWSRequest.prototype.signResponse = function(payload, stringToSign, signatureDateTime) {
     var self = this;
     return new Promise(function (resolve) {
@@ -1621,6 +1626,7 @@
       this.request = request;
     }
     AwsSignature.prototype.request = {};
+    AwsSignature.prototype.error = function () {};
     AwsSignature.prototype.authorizationString = function () {};
     AwsSignature.prototype.stringToSign = function () {};
     AwsSignature.prototype.setHeaders = function () {};
@@ -1679,6 +1685,7 @@
     AwsSignatureV4.prototype.constructor = AwsSignatureV4;
     AwsSignatureV4.prototype._cr = undefined;
     AwsSignatureV4.prototype.payload = null;
+    AwsSignatureV4.prototype.error = function () { this._cr = undefined; };
     AwsSignatureV4.prototype.getPayload = function () {
       return awsRequest.getPayload()
           .then(function (data) {
@@ -1814,14 +1821,11 @@
       };
     };
     AwsSignatureV4.prototype.canonicalRequest = function () {
-      if (typeof this._cr !== 'undefined') {
-        console.log('Reusing canonical request:', this._cr);
-        return this._cr;
-      }
+      if (typeof this._cr !== 'undefined') { return this._cr; }
       var canonParts = [];
 
       canonParts.push(this.request.method);
-      canonParts.push(uri([awsRequest.awsUrl + awsRequest.getPath() + this.request.path].join("")).pathname);
+      canonParts.push(uri([awsRequest.awsUrl, awsRequest.getPath(), this.request.path].join("")).pathname);
       canonParts.push(this.canonicalQueryString() || '');
 
       var headers = this.canonicalHeaders();
@@ -1866,9 +1870,13 @@
         var xhr = new XMLHttpRequest();
         awsRequest.currentXhr = xhr;
 
-
         var stringToSign = awsRequest.stringToSign(),
-            url = [con.signerUrl, '?to_sign=', stringToSign, '&datetime=', request.dateString].join('');
+            url = [con.signerUrl, '?to_sign=', stringToSign, '&datetime=', request.dateString];
+        if (con.sendCanonicalRequestToSignerUrl) {
+          url.push('&canonical_request=');
+          url.push(encodeURIComponent(awsRequest.canonicalRequest()));
+        }
+        url = url.join("");
 
         var signParams = AuthorizationMethod.makeSignParamsObject(fileUpload.signParams);
         for (var param in signParams) {
@@ -1919,6 +1927,7 @@
     }
     AuthorizationCustom.prototype = Object.create(AuthorizationMethod.prototype);
     AuthorizationCustom.prototype.authorize = function () {
+      // TODO: HERE!
       return con.customAuthMethod(
           AuthorizationMethod.makeSignParamsObject(fileUpload.signParams),
           AuthorizationMethod.makeSignParamsObject(con.signHeaders),

--- a/evaporate.js
+++ b/evaporate.js
@@ -1629,6 +1629,7 @@
     AwsSignature.prototype.error = function () {};
     AwsSignature.prototype.authorizationString = function () {};
     AwsSignature.prototype.stringToSign = function () {};
+    AwsSignature.prototype.canonicalRequest = function () {};
     AwsSignature.prototype.setHeaders = function () {};
     AwsSignature.prototype.datetime = function (timeOffset) {
       return new Date(new Date().getTime() + timeOffset);
@@ -1927,12 +1928,12 @@
     }
     AuthorizationCustom.prototype = Object.create(AuthorizationMethod.prototype);
     AuthorizationCustom.prototype.authorize = function () {
-      // TODO: HERE!
       return con.customAuthMethod(
           AuthorizationMethod.makeSignParamsObject(fileUpload.signParams),
           AuthorizationMethod.makeSignParamsObject(con.signHeaders),
           awsRequest.stringToSign(),
-          request.dateString)
+          request.dateString,
+          awsRequest.canonicalRequest())
           .catch(function (reason) {
             fileUpload.deferredCompletion.reject(reason);
             throw reason;

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -389,6 +389,14 @@ test('should fetch V2 authorization using the customAuthMethod without errors', 
         expect(t.context.errMessages.length).to.equal(0)
       })
 })
+test('should fetch V2 authorization using the customAuthMethod with the correct number of parameters', (t) => {
+  const customAuth = sinon.spy(customAuthHandler)
+  return testV2Authorization(t, {signerUrl: undefined, customAuthMethod: customAuth})
+      .then(function () {
+        const a = Array.prototype.slice.call(customAuth.firstCall.args)
+        expect(a.length).to.equal(5)
+      })
+})
 test('should fetch V2 authorization with a customAuthMethod without using signrUrl', (t) => {
   return testV2Authorization(t, {signerUrl: undefined, customAuthMethod: customAuthHandler})
       .then(function () {
@@ -461,6 +469,14 @@ test('should fetch V4 authorization using the customAuthMethod without errors', 
   return testV4Authorization(t, {signerUrl: undefined, customAuthMethod: customAuthHandler})
       .then(function () {
         expect(t.context.errMessages.length).to.equal(0)
+      })
+})
+test('should fetch V4 authorization using the customAuthMethod with the correct number of parameters', (t) => {
+  const customAuth = sinon.spy(customAuthHandler)
+  return testV4Authorization(t, {signerUrl: undefined, customAuthMethod: customAuth})
+      .then(function () {
+        const a = Array.prototype.slice.call(customAuth.firstCall.args)
+        expect(a.length).to.equal(5)
       })
 })
 test('should fetch V4 authorization using the customAuthMethod', (t) => {

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -347,6 +347,14 @@ test('should fetch V2 authorization from the signerUrl', (t) => {
       })
 })
 
+test('should fetch V2 authorization from the signerUrl without canonical_request parameter present', (t) => {
+  return testV4Authorization(t)
+      .then(function () {
+        const x = testRequests[t.context.testId][0];
+        expect(x.url).to.not.match(/canonical_request=/)
+      })
+})
+
 test('should fetch V2 authorization using the signResponseHandler and signerUrl without errors', (t) => {
   return testV2Authorization(t, {signResponseHandler: signResponseHandler})
       .then(function () {
@@ -419,6 +427,23 @@ test('should fetch V4 authorization using the signResponseHandler and signerUrl 
         expect(t.context.errMessages.length).to.equal(0)
       })
 })
+
+test('should fetch V4 authorization from the signerUrl without canonical_request parameter present', (t) => { 
+  return testV4Authorization(t) 
+      .then(function () { 
+        const x = testRequests[t.context.testId][0];
+        expect(x.url).to.not.match(/canonical_request=/) 
+      })
+})
+
+test('should fetch V4 authorization from the signerUrl with canonical_request parameter present, if enabled', (t) => {
+  return testV4Authorization(t, {sendCanonicalRequestToSignerUrl: true})
+      .then(function () {
+        const x = testRequests[t.context.testId][0];
+        expect(x.url).to.match(/canonical_request=/)
+      })
+})
+
 test('should fetch V4 authorization using the signResponseHandler and signerUrl and call the correct signing url', (t) => {
   return testV4Authorization(t, {signResponseHandler: signResponseHandler})
       .then(function () {

--- a/test/evaporate.spec.js
+++ b/test/evaporate.spec.js
@@ -404,8 +404,7 @@ test('should return the object key in the complete callback', (t) => {
   let complete_id
 
   let config = Object.assign({}, baseAddConfig, {
-    complete: sinon.spy(function (xhr, name) { complete_id = name;
-    console.log('name', name)})
+    complete: sinon.spy(function (xhr, name) { complete_id = name; })
   })
 
   return testCommon(t, config)
@@ -425,8 +424,7 @@ test('should correctly encode parentheses for S3', (t) => {
   const c = Object.assign({}, baseAddConfig, {name: '()name()'})
 
   let config = Object.assign({}, c, {
-    complete: sinon.spy(function (xhr, name) { complete_id = name;
-      console.log('name', name)})
+    complete: sinon.spy(function (xhr, name) { complete_id = name; })
   })
 
   return testCommon(t, config)
@@ -442,8 +440,7 @@ test('should correctly encode single quotes for S3', (t) => {
   const c = Object.assign({}, baseAddConfig, {name: "'name'"})
 
   let config = Object.assign({}, c, {
-    complete: sinon.spy(function (xhr, name) { complete_id = name;
-      console.log('name', name)})
+    complete: sinon.spy(function (xhr, name) { complete_id = name; })
   })
 
   return testCommon(t, config)
@@ -458,8 +455,7 @@ test('should correctly encode spaces for S3', (t) => {
   const c = Object.assign({}, baseAddConfig, {name: " name "})
 
   let config = Object.assign({}, c, {
-    complete: sinon.spy(function (xhr, name) { complete_id = name;
-      console.log('name', name)})
+    complete: sinon.spy(function (xhr, name) { complete_id = name; })
   })
 
   return testCommon(t, config)


### PR DESCRIPTION
References #219, #293.

In order to allow developers to verify the string to sign, it's necessary to give access to the [canonical request](http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html ).

This pull request attempts to provide the canonical request to the `signerUrl` and `customAuthMethod` options.

The canonical request is always passed to the `customAuthMethod` as the last argument; however to minimize unnecessary network load, this pr introduces a new option `sendCanonicalRequestToSignerUrl` (default: `false`). When this option is set, the canonical request will be sent as query parameter `canonical_request`.

This PR also optimizes the canonical request to only calculate it once per request and when retrying a request.