### PR TITLE
Adds new callback that delivers the S3 multipart upload ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,9 @@ And a number of optional parameters:
 * **started**: _function(file_key)_. a function that will be called when the file upload starts. The file_key
 represents the internal identifier of the file whose upload is starting.
 
+* **uploadInitiated**: _function(s3UploadId)_. a function that will be called when the S3 upload is successfully initiated.
+  `s3UploadId` is the AWS S3 uploaded ID returned when the multipart upload is initiated.
+
 * **paused**: _function(file_key)_. a function that will be called when the file upload is completely paused (all
 in-progress parts are aborted or completed). The file_key represents the file whose upload has been paused.
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -233,6 +233,7 @@
 
       var fileUpload = new FileUpload(extend({
             started: function () {},
+            uploadInitiated: function () {},
             progress: function () {},
             complete: function () {},
             cancelled: function () {},
@@ -923,6 +924,7 @@
         .send()
         .then(
             function () {
+              self.uploadInitiated(self.uploadId);
               self.partsToUpload = [];
               return self.uploadParts()
                   .then(

--- a/test/evaporate.spec.js
+++ b/test/evaporate.spec.js
@@ -492,6 +492,19 @@ test('should call a callback on successful add()', (t) => {
       })
 })
 
+test('should call a callback on successful initiate()', (t) => {
+  const initated_spy = sinon.spy()
+
+  const config = Object.assign({}, baseAddConfig, {
+    uploadInitiated: initated_spy
+  })
+
+  return testCommon(t, config)
+      .then(function () {
+        expect(initated_spy.withArgs('Hzr2sK034dOrV4gMsYK.MMrtWIS8JVBPKgeQ.LWd6H8V2PsLecsBqoA1cG1hjD3G4KRX_EBEwxWWDu8lNKezeA--').calledOnce).to.be.true
+      })
+})
+
 test('should call a progress with stats callback on successful add()', (t) => {
   return testCommon(t, {progress: sinon.spy()})
       .then(function () {


### PR DESCRIPTION
The callback is optional and is invoked as soon as the S3 multipart upload ID is determined. http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html