### PR TITLE
Allows AWS_URL to be set per file added

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -32,7 +32,6 @@
         'maxConcurrentParts',
         'logging',
         'cloudfront',
-        'aws_url',
         'encodeFilename',
         'computeContentMd5',
         'allowS3ExistenceOptimization',
@@ -1978,8 +1977,14 @@
   }
 
   function uri(url) {
-    var p = document.createElement('a');
-    p.href = url || "/";
+    var p,
+        href = url || '/';
+    if (typeof URL === 'undefined') {
+      p = document.createElement('a');
+      p.href = href;
+    } else {
+      p = new URL(href);
+    }
 
     return {
       protocol: p.protocol, // => "http:"

--- a/test/aws_url.spec.js
+++ b/test/aws_url.spec.js
@@ -7,10 +7,10 @@ import test from 'ava'
 let server
 // test that AWS Url obeys the contract
 
-function testAwsUrl(t, input) {
+function testAwsUrl(t, input, addC) {
   return new Promise(function (resolve) {
     let evapConfig = Object.assign({}, {awsSignatureVersion: '2'}, input)
-    testBase(t, {}, evapConfig)
+    testBase(t, addC || {}, evapConfig)
         .then(function () {
           resolve(testRequests[t.context.testId][1].url)
         })
@@ -86,6 +86,15 @@ test('should respect aws_url if presented with cloudfront', (t) => {
         expect(url).to.match(new RegExp('https://s3.dualstack.us-east-1.amazonaws.com'))
       })
 })
+
+test.only('should allow the aws_url to be overriddden on add', (t) => {
+  return testAwsUrl(t, { awsRegion: 'eu-central-1', aws_url: 'https://s3.dualstack.us-east-1.amazonaws.com', cloudfront: true },
+      { configOverrides: { aws_url: 'https://s3.dualstack.us-east-3.amazonaws.com'} })
+      .then(function (url) {
+        expect(url).to.match(new RegExp('https://s3.dualstack.us-east-3.amazonaws.com'))
+      })
+})
+
 
 // S3 Transfer Acceleration
 


### PR DESCRIPTION
With the refactoring in 2.0, it appears that the aws_url configuration option can be set on the `Evaporate#add`. Also attempts to use any builtin `URL` object to parse the url, falling back to `document` as a polyfill.