### PR TITLE
Fixes #316

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -2036,6 +2036,8 @@
     }
 
     obj1 = obj1 || {};
+    obj2 = obj2 || {};
+    obj3 = obj3 || {};
     ext(obj2, obj3);
     ext(obj1, obj2);
 


### PR DESCRIPTION
The extend function used to replace Object.assign for #307 was not fully compatible with Object.assign, which prevented uploading files when localStorage was unavailable. Fixes #316 