### PR TITLE
Adds option to use local cache instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Available configuration options:
 * **cryptoHexEncodedHash256**: default=undefined, a method that computes the lowercase base 16 encoded SHA256 hash. Required when `awsSignatureVersion` is `'4'`.
     - Node.js: `function (data) { return crypto.createHash('sha256').update(data).digest('hex'); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.sha256(data, 'hex'); }`.
+* **mockLocalStorage**: default=false, whether to fallback to a local object to cache Evaporate upload attempts. Se this if you want
+    to resume uploads in non-browser environments. If set, then a plain old JavaScript object will be used instead of localStorage.
 * **s3FileCacheHoursAgo**: default=null (no cache), whether to use the S3 uploaded cache of parts and files for ease of recovering after
     client failure or page refresh. The value should be a whole number representing the number of hours ago to check for uploaded parts
     and files. The uploaded parts and and file status are retrieved from S3. If no cache is set, Evaporate will not resume uploads after

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Available configuration options:
 * **cryptoHexEncodedHash256**: default=undefined, a method that computes the lowercase base 16 encoded SHA256 hash. Required when `awsSignatureVersion` is `'4'`.
     - Node.js: `function (data) { return crypto.createHash('sha256').update(data).digest('hex'); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.sha256(data, 'hex'); }`.
-* **mockLocalStorage**: default=false, whether to for use a local object to cache Evaporate upload attempts, rather than
+* **mockLocalStorage**: default=false, whether to use a local object to cache Evaporate upload attempts, rather than
     `localStorage`. Set this if you want to resume uploads in non-browser environments. If set, then a plain old
     JavaScript object will be used instead of `localStorage`, even if `localStorage` is supported by the environment.
 * **s3FileCacheHoursAgo**: default=null (no cache), whether to use the S3 uploaded cache of parts and files for ease of recovering after

--- a/README.md
+++ b/README.md
@@ -389,8 +389,9 @@ Available configuration options:
 * **cryptoHexEncodedHash256**: default=undefined, a method that computes the lowercase base 16 encoded SHA256 hash. Required when `awsSignatureVersion` is `'4'`.
     - Node.js: `function (data) { return crypto.createHash('sha256').update(data).digest('hex'); }`.
     - AWS SDK for JavaScript: `function (data) { return AWS.util.crypto.sha256(data, 'hex'); }`.
-* **mockLocalStorage**: default=false, whether to fallback to a local object to cache Evaporate upload attempts. Se this if you want
-    to resume uploads in non-browser environments. If set, then a plain old JavaScript object will be used instead of localStorage.
+* **mockLocalStorage**: default=false, whether to for use a local object to cache Evaporate upload attempts, rather than
+    `localStorage`. Set this if you want to resume uploads in non-browser environments. If set, then a plain old
+    JavaScript object will be used instead of `localStorage`, even if `localStorage` is supported by the environment.
 * **s3FileCacheHoursAgo**: default=null (no cache), whether to use the S3 uploaded cache of parts and files for ease of recovering after
     client failure or page refresh. The value should be a whole number representing the number of hours ago to check for uploaded parts
     and files. The uploaded parts and and file status are retrieved from S3. If no cache is set, Evaporate will not resume uploads after

--- a/evaporate.js
+++ b/evaporate.js
@@ -58,6 +58,7 @@
       progressIntervalMS: 1000,
       cloudfront: false,
       s3Acceleration: false,
+      mockLocalStorage: false,
       encodeFilename: true,
       computeContentMd5: false,
       allowS3ExistenceOptimization: false,
@@ -116,6 +117,7 @@
     this.pendingFiles = {};
     this.queuedFiles = [];
     this.filesInProcess = [];
+    historyCache = new HistoryCache(this.config.mockLocalStorage);
   };
   Evaporate.create = function (config) {
     var evapConfig = extend({}, config);
@@ -2118,54 +2120,35 @@
     return [size.toFixed(2).replace('.00', ''), units[i]].join(" ");
   }
 
-  var historyCache = {
-    supported: function () {
-      var result = false;
-      if (typeof window !== 'undefined') {
-        if (!('localStorage' in window)) {
-          return result;
-        }
-      } else {
+  var historyCache;
+  function HistoryCache(mockLocalStorage) {
+    var supported = HistoryCache.supported();
+    this.cacheStore = supported ? localStorage : (mockLocalStorage ? {} : undefined);
+  }
+  HistoryCache.prototype.supported = false;
+  HistoryCache.prototype.cacheStore = undefined;
+  HistoryCache.prototype.getItem = function (key) { if (this.cacheStore) { return this.cacheStore[key]; }};
+  HistoryCache.prototype.setItem = function (key, value) { if (this.cacheStore) { this.cacheStore[key] = value; }};
+  HistoryCache.prototype.removeItem = function (key) { if (this.cacheStore) { return delete this.cacheStore[key] }};
+  HistoryCache.supported = function () {
+    var result = false;
+    if (typeof window !== 'undefined') {
+      if (!('localStorage' in window)) {
         return result;
       }
-
-      // Try to use storage (it might be disabled, e.g. user is in private mode)
-      try {
-        localStorage.setItem('___test', 'OK');
-        var test = localStorage.getItem('___test');
-        localStorage.removeItem('___test');
-
-        result = test === 'OK';
-      } catch (e) {
-        return result;
-      }
-
+    } else {
       return result;
-    },
-    getItem: function (key) {
-      if (this.supported()) {
-        return localStorage.getItem(key)
-      }
-    },
-    setItem: function (key, value) {
-      if (this.supported()) {
-        return localStorage.setItem(key, value);
-      }
-    },
-    clear: function () {
-      if (this.supported()) {
-        return localStorage.clear();
-      }
-    },
-    key: function (key) {
-      if (this.supported()) {
-        return localStorage.key(key);
-      }
-    },
-    removeItem: function (key) {
-      if (this.supported()) {
-        return localStorage.removeItem(key);
-      }
+    }
+
+    // Try to use storage (it might be disabled, e.g. user is in private mode)
+    try {
+      var k = '___test';
+      localStorage[k] = 'OK';
+      var test = localStorage[k];
+      delete localStorage[k];
+      return test === 'OK';
+    } catch (e) {
+      return result;
     }
   };
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -2123,7 +2123,7 @@
   var historyCache;
   function HistoryCache(mockLocalStorage) {
     var supported = HistoryCache.supported();
-    this.cacheStore = supported ? localStorage : (mockLocalStorage ? {} : undefined);
+    this.cacheStore = mockLocalStorage ? {} : (supported ? localStorage : undefined);
   }
   HistoryCache.prototype.supported = false;
   HistoryCache.prototype.cacheStore = undefined;

--- a/test/s3-object-reuse.spec.js
+++ b/test/s3-object-reuse.spec.js
@@ -2,9 +2,9 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 import test from 'ava'
 
-let server
+let server, storage
 
-function testS3Reuse(t, addConfig2, headEtag, evapConfig2) {
+function testS3Reuse(t, addConfig2, headEtag, evapConfig2, mockConfig) {
   addConfig2 = addConfig2 || {}
   t.context.headEtag = headEtag
 
@@ -16,12 +16,12 @@ function testS3Reuse(t, addConfig2, headEtag, evapConfig2) {
   }
 
   // Upload the first time
-  return testBase(t, {}, evapConfig)
+  return testBase(t, {}, Object.assign({}, evapConfig, mockConfig))
       .then(function () {
         t.context.originalName = t.context.requestedAwsObjectKey
         addConfig2.name = randomAwsKey()
         // Upload the second time to trigger head
-        evapConfig = Object.assign({}, evapConfig, evapConfig2 || {})
+        evapConfig = Object.assign({}, evapConfig, evapConfig2, mockConfig)
         t.context.requestedAwsObjectKey = addConfig2.name
         return testBase(t, addConfig2, evapConfig)
       })
@@ -36,6 +36,7 @@ test.before(() => {
   };
 
   server = serverCommonCase()
+  storage = global.localStorage
 })
 
 test.beforeEach((t) => {
@@ -56,16 +57,52 @@ test('should re-use S3 object with S3 requests correctly ordered', (t) => {
             'initiate,PUT:partNumber=1,PUT:partNumber=2,complete,HEAD')
       })
 })
+test.serial('should not re-use S3 object with S3 requests correctly ordered, mocking localStorage', (t) => {
+  return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"', {}, { mockLocalStorage: true })
+      .then(function () {
+        expect(requestOrder(t)).to.equal(
+            'initiate,PUT:partNumber=1,PUT:partNumber=2,complete,initiate,PUT:partNumber=1,PUT:partNumber=2,complete')
+      })
+})
+test.serial('should not re-use S3 object with S3 requests correctly ordered, no localStorage, not mocking', (t) => {
+  global['localStorage'] = undefined
+  return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"')
+      .then(function () {
+        global.localStorage = storage
+        expect(requestOrder(t)).to.equal(
+            'initiate,PUT:partNumber=1,PUT:partNumber=2,complete,initiate,PUT:partNumber=1,PUT:partNumber=2,complete')
+      })
+})
 test('should re-use S3 object calling cryptomd5 correctly', (t) => {
   return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"')
       .then(function () {
         expect(t.context.completedAwsKey).to.not.equal(t.context.requestedAwsObjectKey)
       })
 })
+test.serial('should not re-use S3 object calling cryptomd5 correctly, mocking localStorage', (t) => {
+  return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"', {}, { mockLocalStorage: true })
+      .then(function () {
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
 test('should re-use S3 object returning the S3 file upload ID', (t) => {
   return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"')
       .then(function () {
         expect(t.context.completedAwsKey).to.not.equal(t.context.requestedAwsObjectKey)
+      })
+})
+test.serial('should not re-use S3 object returning the S3 file upload ID, mocking localStorage', (t) => {
+  return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"', {}, { mockLocalStorage: true })
+      .then(function () {
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
+test.serial('should not re-use S3 object returning the S3 file upload ID, no localStorage, not mocking', (t) => {
+  global['localStorage'] = undefined
+  return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"')
+      .then(function () {
+        global.localStorage = storage
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
       })
 })
 test('should re-use S3 object and callback complete with first param instance of xhr', (t) => {
@@ -170,7 +207,6 @@ test('should not re-use S3 object because the Etag does not match callback compl
 
 test('should not re-use S3 object if headObject returns 404', (t) => {
   t.context.headStatus = 404
-
   return testS3Reuse(t, {}, '"b2969107bdcfc6aa30892ee0867ebe79-1"')
       .then(function () {
         expect(requestOrder(t)).to.equal(


### PR DESCRIPTION
For environments that do not support localStorage, this enhancement adds the option to mock localStorage using a plain old JavaScript object. Supports #319.
@YMIndustries what do you think?