### PR TITLE
Removes dependence on a DOM parser for greater compatibility with browser-less environments

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -2006,14 +2006,14 @@
   }
 
   function getAwsResponse(xhr) {
-    var oParser = new DOMParser(),
-        oDOM = oParser.parseFromString(xhr.responseText, "text/html"),
-        code = oDOM.getElementsByTagName("Code"),
-        msg = oDOM.getElementsByTagName("Message");
-    code = code && code.length ? (code[0].innerHTML || code[0].textContent) : '';
-    msg = msg && msg.length ? (msg[0].innerHTML || msg[0].textContent) : '';
-
+    var code = elementText(xhr.responseText, "Code"),
+        msg = elementText(xhr.responseText, "Message");
     return code.length ? ['AWS Code: ', code, ', Message:', msg].join("") : '';
+  }
+
+  function elementText(source, element) {
+    var match = source.match(["<", element, ">(.+)</", element, ">"].join(""));
+    return match ? match[1] : '';
   }
 
   function defer() {

--- a/evaporate.js
+++ b/evaporate.js
@@ -857,9 +857,7 @@
         .send()
         .then(
             function (xhr) {
-              var oDOM = parseXml(xhr.responseText),
-                  result = oDOM.getElementsByTagName("CompleteMultipartUploadResult")[0];
-              self.eTag = nodeValue(result, "ETag");
+              self.eTag = elementText(xhr.responseText, "ETag").replace(/&quot;/g, '"');
               self.completeUploadFile(xhr);
             });
   };

--- a/evaporate.js
+++ b/evaporate.js
@@ -820,25 +820,23 @@
   };
   FileUpload.prototype.listPartsSuccess = function (listPartsRequest, partsXml) {
     this.info('uploadId', this.uploadId, 'is not complete. Fetching parts from part marker', listPartsRequest.partNumberMarker);
-    var oDOM = parseXml(partsXml),
-        listPartsResult = oDOM.getElementsByTagName("ListPartsResult")[0],
-        uploadedParts = oDOM.getElementsByTagName("Part"),
-        parts_len = uploadedParts.length,
-        cp, partSize;
+    partsXml = partsXml.replace(/(\r\n|\n|\r)/gm, ""); // strip line breaks to ease the regex requirements
+    var partRegex = /<Part>(.+?)<\/Part\>/g;
 
-    for (var i = 0; i < parts_len; i++) {
-      cp = uploadedParts[i];
-      partSize = parseInt(nodeValue(cp, "Size"), 10);
+    while (true) {
+      var cp = (partRegex.exec(partsXml) || [])[1];
+      if (!cp) { break; }
+
+      var partSize = parseInt(elementText(cp, "Size"), 10);
       this.fileTotalBytesUploaded += partSize;
       this.partsOnS3.push({
-        eTag: nodeValue(cp, "ETag"),
-        partNumber: parseInt(nodeValue(cp, "PartNumber"), 10),
+        eTag: elementText(cp, "ETag").replace(/&quot;/g, '"'),
+        partNumber: parseInt(elementText(cp, "PartNumber"), 10),
         size: partSize,
-        LastModified: nodeValue(cp, "LastModified")
+        LastModified: elementText(cp, "LastModified")
       });
     }
-
-    return listPartsResult;
+    return elementText(partsXml, "IsTruncated") === 'true' ? elementText(partsXml, "NextPartNumberMarker") : undefined;
   };
   FileUpload.prototype.makePartsfromPartsOnS3 = function () {
     if (ACTIVE_STATUSES.indexOf(this.status) === -1) { return; }
@@ -1337,11 +1335,9 @@
       return this.rejectedSuccess('uploadId ', this.fileUpload.id, ' not found on S3.');
     }
 
-    var listPartsResult = this.fileUpload.listPartsSuccess(this, xhr.responseText);
-    var isTruncated = nodeValue(listPartsResult, "IsTruncated") === 'true';
-
-    if (isTruncated) {
-      var request = this.setupRequest(nodeValue(listPartsResult, "NextPartNumberMarker")); // let's fetch the next set of parts
+    var nextPartNumber = this.fileUpload.listPartsSuccess(this, xhr.responseText);
+    if (nextPartNumber) {
+      var request = this.setupRequest(nextPartNumber); // let's fetch the next set of parts
       this.updateRequest(request);
       this.trySend();
     } else {
@@ -2043,15 +2039,6 @@
     ext(obj1, obj2);
 
     return obj1;
-  }
-
-  function parseXml(body) {
-    var parser = new DOMParser();
-    return parser.parseFromString(body, "text/xml");
-  }
-
-  function nodeValue(parent, nodeName) {
-    return parent.getElementsByTagName(nodeName)[0].textContent;
   }
 
   function getSavedUploads(purge) {


### PR DESCRIPTION
Now that Evaporate is being used in browser and browser-less environments, it makes sense to remove any unnecessary browser dependencies. This pull request removes all dependencies to  DOM parser as these dependencies are not thread safe and restrict compatibilities on web workers.