### PR TITLE
Fix Node.js example + add logging

### DIFF
--- a/example/SigningExample.js
+++ b/example/SigningExample.js
@@ -17,7 +17,7 @@ app.use(bodyParser.urlencoded({
 	extended: true
 }));
 
-app.listen(8080, '127.0.0.1', function() {
+app.listen(8080, '127.0.0.1', function () {
 	console.log('Listening on 127.0.0.1:8080');
 });
 

--- a/example/SigningExample.js
+++ b/example/SigningExample.js
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 //npm install express body-parser and navigate to http://127.0.0.1:8080/index.html
 var express = require('express');
 var bodyParser = require('body-parser');
@@ -7,19 +7,28 @@ var crypto = require('crypto');
 var app = express();
 app.use(express.static(require('path').join( __dirname + '/../')));
 
+// Add simple logging middleware
+app.use(function(req, res, next) {
+  console.log(req.method + ' ' + req.originalUrl);
+  next();
+});
+
 app.use(bodyParser.urlencoded({
 	extended: true
 }));
 
-app.listen(8080, '127.0.0.1');
+app.listen(8080, '127.0.0.1', function() {
+	console.log('Listening on 127.0.0.1:8080');
+});
 
 app.use('/sign_auth', function (req, res) {
 	// TODO: Do something to authenticate this request
-	res.send(crypto
-		.createHmac('sha1', env.AWS_SECRET)
+	var signature = crypto
+		.createHmac('sha1', process.env.AWS_SECRET)
 		.update(req.query.to_sign)
 		.digest('base64')
-	);
+	console.log('Created signature "' + signature + '" from ' + req.query.to_sign);
+	res.send(signature);
 });
 
 app.get('/index.html', function (req, res) {


### PR DESCRIPTION
Fixes:

 - envvars must be accessed through `process.env.<ENVVAR>`
 - on most linux machines, the `env` utility is located at /usr/bin/env

Logging improvements:

 - log when a server opens a connection on a port (otherwise I find myself wondering if the server process is running and where)
 - log each request's method and url
 - log the request payload and signature for url signer endpoint

cc @bikeath1337