### PR TITLE
set content type on each part when in Edge

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -21,6 +21,8 @@
 (function () {
   "use strict";
 
+  var Promise = require("es6-promise-polyfill").Promise;
+
   var FAR_FUTURE = new Date('2060-10-22'),
       HOURS_AGO,
       PENDING = 0, EVAPORATING = 2, COMPLETE = 3, PAUSED = 4, CANCELED = 5, ERROR = 10, ABORTED = 20, PAUSING = 30,

--- a/evaporate.js
+++ b/evaporate.js
@@ -1364,6 +1364,10 @@
       onProgress: this.onProgress.bind(this)
     };
 
+    if(/Edge\/\d+/.test(navigator.userAgent) && fileUpload.contentType) {
+      request.contentType = fileUpload.contentType;
+    }
+
     SignedS3AWSRequest.call(this, fileUpload, request);
   }
   PutPart.prototype = Object.create(SignedS3AWSRequest.prototype);

--- a/evaporate.js
+++ b/evaporate.js
@@ -454,12 +454,11 @@
     this.evaporate = evaporate;
     this.localTimeOffset = evaporate.localTimeOffset;
     this.deferredCompletion = defer();
+    this.signParams = con.signParams;
 
     extend(this, file);
 
     this.id = decodeURIComponent(this.con.bucket + '/' + this.name);
-
-    this.signParams = con.signParams;
   }
   FileUpload.prototype.con = undefined;
   FileUpload.prototype.evaporate = undefined;
@@ -751,7 +750,7 @@
           fileType: this.file.type,
           lastModifiedDate: dateISOString(this.file.lastModified),
           partSize: this.con.partSize,
-          signParams: this.con.signParams,
+          signParams: this.signParams || this.con.signParams,
           createdAt: new Date().toISOString()
         };
     saveUpload(fileKey, newUpload);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   },
   "license": "BSD 3-Clause",
   "homepage": "https://github.com/TTLabs/EvaporateJS",
+  "dependencies": {
+    "es6-promise-polyfill": "^1.2.0"
+  },
   "devDependencies": {
     "ava": "^0.16.0",
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
It looks like in Edge, it is necessary to include the "Content Type" in the signature of each part, because otherwise S3 will fail with a "signature mismatch" error.