### PR TITLE
Set `PAUSED` status after force pausing

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -622,6 +622,7 @@
     this.status = PAUSING;
     if (force) {
       this.abortParts(true);
+      this.status = PAUSED;
     } else {
       promises = this.partsInProcess.map(function (p) {
         return this.s3Parts[p].awsRequest.awsDeferred.promise


### PR DESCRIPTION
**Use-case**: force pause ongoing upload
**Expected result**: upload changes its status to PAUSING, then momentarily changes status to PAUSED.
**Actual result**: upload changes its status to PAUSING and remains with this status.

This PR implements changing status to PAUSED right after aborting requests.

As for test coverage, I'm afraid, I will not be able to do that.