### PR TITLE
Applies the contentType to all signatures for all requests

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1018,7 +1018,12 @@
     this.awsUrl = awsUrl(this.con);
     this.awsHost = uri(this.awsUrl).hostname;
 
-    this.updateRequest(request);
+    var r = extend({}, request);
+    if (fileUpload.contentType) {
+      r.contentType = fileUpload.contentType;
+    }
+
+    this.updateRequest(r);
   }
   SignedS3AWSRequest.prototype.fileUpload = undefined;
   SignedS3AWSRequest.prototype.con = undefined;
@@ -1237,10 +1242,6 @@
       not_signed_headers: fileUpload.notSignedHeadersAtInitiate,
       response_match: '<UploadId>(.+)<\/UploadId>'
     };
-
-    if (fileUpload.contentType) {
-      request.contentType = fileUpload.contentType;
-    }
 
     CancelableS3AWSRequest.call(this, fileUpload, request);
     this.awsKey = awsKey;

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -38,7 +38,7 @@ function testV2ToSign(t, request, amzHeaders, addConfig, evapConfig) {
       .then(function () {
         var qp = params(testRequests[t.context.testId][2].url),
             h = Object.assign({}, amzHeaders, {testId: t.context.testId, 'x-amz-date': qp.datetime}),
-            r = Object.assign({}, request, {x_amz_headers: h}),
+            r = Object.assign({}, request, {x_amz_headers: h, contentType: (addConfig ? addConfig.contentType : undefined)}),
             expected = encodeURIComponent(stringToSignV2('/' + AWS_BUCKET + '/' + t.context.config.name +
                 '?partNumber=1&uploadId=Hzr2sK034dOrV4gMsYK.MMrtWIS8JVBPKgeQ.LWd6H8V2PsLecsBqoA1cG1hjD3G4KRX_EBEwxWWDu8lNKezeA--', 'PUT', r))
 
@@ -221,6 +221,12 @@ test.beforeEach((t) =>{
 
 test('should correctly create V2 string to sign for PUT', (t) => {
   return testV2ToSign(t)
+      .then(function (result) {
+        expect(result.result).to.equal(result.expected)
+      })
+})
+test('should correctly create V2 string to sign with contentType', (t) => {
+  return testV2ToSign(t, {}, {}, {contentType: 'video/mp4'})
       .then(function (result) {
         expect(result.result).to.equal(result.expected)
       })


### PR DESCRIPTION
Previously the PUT method was excluded. This may be the reason for some Micorosoft Edge compatibility.

Anyone able to give this branch a trial run? It works on Apple Version 60.0.3112.90 (Official Build) (64-bit). 

Might supersede #363