### PR TITLE
Adds Automatic Support to Not Use Multipart Uploads If File Size <= `partSize`

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1381,8 +1381,8 @@
     return new Promise(function (resolve, reject) {
       if (self.con.computeContentMd5 && !part.md5_digest) {
         self.getPayload()
-            .then(function (data) {
-              var md5_digest = self.con.cryptoMd5Method(data);
+            .then(self.con.cryptoMd5Method)
+            .then(function (md5_digest) {
               if (self.partNumber === 1 && self.con.computeContentMd5 && typeof self.fileUpload.firstMd5Digest === "undefined") {
                 self.fileUpload.firstMd5Digest = md5_digest;
                 self.fileUpload.updateUploadFile({firstMd5Digest: md5_digest})

--- a/evaporate.js
+++ b/evaporate.js
@@ -712,7 +712,7 @@
       } else {
         s3Part = this.makePart(part, PENDING, this.sizeBytes);
       }
-      s3Part.awsRequest = new PutPart(this, s3Part);
+      s3Part.awsRequest = this.numParts === 1 && this.con.enablePartSizeOptimization ?  new PutObject(this, s3Part) : new PutPart(this, s3Part);
       s3Part.awsRequest.awsDeferred.promise
           .then(resolve(s3Part), reject(s3Part));
 
@@ -863,7 +863,11 @@
         .send()
         .then(
             function (xhr) {
-              self.eTag = elementText(xhr.responseText, "ETag").replace(/&quot;/g, '"');
+              if (self.numParts === 1 && self.con.enablePartSizeOptimization) {
+                self.eTag = self.partsOnS3[0].eTag;
+              } else {
+                self.eTag = elementText(xhr.responseText, "ETag").replace(/&quot;/g, '"');
+              }
               self.completeUploadFile(xhr);
             });
   };

--- a/evaporate.js
+++ b/evaporate.js
@@ -1592,6 +1592,27 @@
   };
 
 
+  //http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+  function PutObject(fileUpload, part) {
+    this.part = part;
+
+    this.partNumber = 1;
+    this.start = 0;
+    this.end = fileUpload.sizeBytes;
+
+    var request = {
+      method: 'PUT',
+      step: 'upload #' + this.partNumber,
+      x_amz_headers: fileUpload.xAmzHeadersCommon || fileUpload.xAmzHeadersAtUpload,
+      onProgress: this.onProgress.bind(this)
+    };
+
+    SignedS3AWSRequest.call(this, fileUpload, request);
+  }
+  PutObject.prototype = Object.create(PutPart.prototype);
+  PutObject.prototype.constructor = PutObject;
+
+
   //http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadAbort.html
   function DeleteMultipartUpload(fileUpload) {
     fileUpload.info('will attempt to abort the upload');

--- a/evaporate.js
+++ b/evaporate.js
@@ -460,6 +460,7 @@
     this.id = decodeURIComponent(this.con.bucket + '/' + this.name);
 
     this.signParams = con.signParams;
+    this.numParts = Math.ceil(this.sizeBytes / this.con.partSize) || 1; // issue #58
   }
   FileUpload.prototype.con = undefined;
   FileUpload.prototype.evaporate = undefined;
@@ -678,7 +679,6 @@
     });
   };
   FileUpload.prototype.makeParts = function (firstPart) {
-    this.numParts = Math.ceil(this.sizeBytes / this.con.partSize) || 1; // issue #58
     var partsDeferredPromises = [];
 
     var self = this;

--- a/evaporate.js
+++ b/evaporate.js
@@ -60,6 +60,7 @@
       logging: true,
       maxConcurrentParts: 5,
       partSize: 6 * 1024 * 1024,
+      enablePartSizeOptimization: true,
       retryBackoffPower: 2,
       maxRetryBackoffSecs: 300,
       progressIntervalMS: 1000,

--- a/test/helpers/browser-env.js
+++ b/test/helpers/browser-env.js
@@ -75,7 +75,8 @@ let requestMap = {
   'POST:uploads': 'initiate',
   'POST:uploadId': 'complete',
   'DELETE:uploadId': 'cancel',
-  'GET:uploadId': 'check for parts'
+  'GET:uploadId': 'check for parts',
+  'PUT': 'put object'
 }
 
 global.requestOrder = function (t) {

--- a/test/helpers/browser-env.js
+++ b/test/helpers/browser-env.js
@@ -45,7 +45,8 @@ const baseConfig = {
   bucket: AWS_BUCKET,
   logging: false,
   maxRetryBackoffSecs: 0.1,
-  abortCompletionThrottlingMs: 0
+  abortCompletionThrottlingMs: 0,
+  enablePartSizeOptimization: false
 }
 
 function LocalStorage() {

--- a/test/optimized-part-size.spec.js
+++ b/test/optimized-part-size.spec.js
@@ -1,0 +1,173 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import test from 'ava'
+
+// constants
+
+let server
+
+
+function testCommon(t, addCfg, initConfig) {
+  let addConfig = Object.assign({}, { file: new File({
+    path: '/tmp/file',
+    size: 50,
+    name: 'tests'
+  })}, addCfg)
+
+  let evapConfig = Object.assign({}, {awsSignatureVersion: '2', enablePartSizeOptimization: true}, initConfig)
+  return testBase(t, addConfig, evapConfig)
+}
+function testMd5V2(t) {
+  return testCommon(t, {}, { awsSignatureVersion: '2', computeContentMd5: true })
+}
+
+function testMd5V4(t) {
+  return testCommon(t, {}, {
+    computeContentMd5: true,
+    cryptoHexEncodedHash256: function (d) { return d; }
+  })
+}
+
+
+
+test.before(() => {
+  sinon.xhr.supportsCORS = true
+  global.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
+  global.window = {
+    localStorage: {},
+    console: console
+  };
+
+  server = serverCommonCase()
+})
+
+test.beforeEach((t) => {
+  beforeEachSetup(t)
+})
+
+// Callbacks
+test('should call a callback on successful add()', (t) => {
+  return testCommon(t)
+      .then(function () {
+        expect(t.context.config.started.withArgs('bucket/' + t.context.requestedAwsObjectKey).calledOnce).to.be.true
+      })
+})
+test('should call a progress with stats callback on successful add()', (t) => {
+  return testCommon(t, {progress: sinon.spy()})
+      .then(function () {
+        expect(t.context.config.progress.firstCall.args.length).to.equal(2)
+        expect(typeof t.context.config.progress.firstCall.args[1]).to.equal('object')
+      })
+})
+test('should return the object key in the complete callback', (t) => {
+  let complete_id
+
+  let config = Object.assign({}, {}, {
+    name:  AWS_UPLOAD_KEY,
+    complete: sinon.spy(function (xhr, name) { complete_id = name; })
+  })
+
+  return testCommon(t, config)
+      .then(function () {
+        expect(complete_id).to.equal(config.name)
+        expect(t.context.config.complete.firstCall.args.length).to.equal(3)
+        expect(t.context.config.complete.firstCall.args[0]).to.be.undefined
+        expect(typeof t.context.config.complete.firstCall.args[1]).to.equal('string')
+        expect(typeof t.context.config.complete.firstCall.args[2]).to.equal('object')
+      })
+
+})
+
+
+// Default Setup: V2 signatures: Common Case
+test('should not call cryptoMd5 upload a file with defaults and V2 signature', (t) => {
+  return testCommon(t, {}, { awsSignatureVersion: '2' })
+      .then(function () {
+        expect(t.context.cryptoMd5.callCount).to.equal(0)
+      })
+})
+test('should upload a file with S3 requests in the correct order', (t) => {
+  return testCommon(t)
+      .then(function () {
+        expect(requestOrder(t)).to.equal('put object')
+      })
+})
+test('should upload a file and return the correct file upload ID', (t) => {
+  return testCommon(t)
+      .then(function () {
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
+test('should upload a file and callback complete once', (t) => {
+  return testCommon(t)
+      .then(function () {
+        expect(t.context.config.complete.calledOnce).to.be.true
+      })
+})
+test('should upload a file and callback complete with second param the awsKey', (t) => {
+  return testCommon(t)
+      .then(function () {
+        expect(t.context.config.complete.firstCall.args[1]).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
+test('should upload a file and not callback with a changed object name', (t) => {
+  return testCommon(t, {nameChanged: sinon.spy()})
+      .then(function () {
+        expect(t.context.config.nameChanged.callCount).to.equal(0)
+      })
+})
+
+// md5Digest tests
+test('V2 should call cryptoMd5 when uploading a file with defaults', (t) => {
+  return testMd5V2(t)
+      .then(function () {
+        expect(t.context.cryptoMd5.callCount).to.equal(1)
+      })
+})
+test('V2 should upload a file with MD5Digests with S3 requests in the correct order', (t) => {
+  return testMd5V2(t)
+      .then(function () {
+        expect(requestOrder(t)).to.equal('put object')
+      })
+})
+test('V2 should upload a file and return the correct file upload ID', (t) => {
+  return testMd5V2(t)
+      .then(function () {
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
+
+test('V4 should call cryptoMd5 when uploading a file with defaults', (t) => {
+  return testMd5V4(t)
+      .then(function () {
+        expect(t.context.cryptoMd5.callCount).to.equal(1)
+      })
+})
+test('V4 should upload a file with MD5Digests with S3 requests in the correct order', (t) => {
+  return testMd5V4(t)
+      .then(function () {
+        expect(requestOrder(t)).to.equal('put object')
+      })
+})
+test('V4 should upload a file and return the correct file upload ID', (t) => {
+  return testMd5V4(t)
+      .then(function () {
+        expect(t.context.completedAwsKey).to.equal(t.context.requestedAwsObjectKey)
+      })
+})
+
+test('should retry Upload Part', (t) => {
+  t.context.retry = function (type) {
+    return type === 'part'
+  }
+
+  return testCommon(t, { file: new File({
+        path: '/tmp/file',
+        size: 50,
+        name: 'tests'
+      })
+    })
+      .then(function () {
+        expect(requestOrder(t)).to.equal('put object,put object')
+      })
+})


### PR DESCRIPTION
Thanks to @jakubzitny for #362.

This PR has not be tested yet, but specs pass (I will remove the WIP after doing more testing).

What this intends to do: Enhance Evaporate to avoid the overhead of using multipart uploads if the file size is equal to the part size. This option avoids two round trips to AWS (initiate and complete).

Description:

- The feature is enabled by default. To disable, use the provided option `enablePartSizeOptimization`
- The `started`, `progress` and `complete` callbacks should all be invoked
- `computeContentMd5` should be respected
- Retry features should be maintained

Changes:
- The complete callback's `xhr` parameter will be `undefined`.