### PR TITLE
fix bug  upload files with spaces

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1865,7 +1865,7 @@
             url = [con.signerUrl, '?to_sign=', stringToSign, '&datetime=', request.dateString];
         if (con.sendCanonicalRequestToSignerUrl) {
           url.push('&canonical_request=');
-          url.push(encodeURIComponent(awsRequest.canonicalRequest()));
+          url.push(encodeURIComponent(decodeURI(awsRequest.canonicalRequest())));
         }
         url = url.join("");
 


### PR DESCRIPTION
This is a fix of uploading files with spaces in names that was encoded twice and that's why canonical request was wrong ( %20 was replaced by %2520 )