### PR TITLE
Fix issue undefined is not an object evaluating undefined is not an object (evaluating p.search[0]) uri SignedS3AWSRequest

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1976,6 +1976,7 @@
 
     try {
       p = new URL(href);
+      p.search = p.search || "";
     } catch (e) {
       p = document.createElement('a');
       p.href = href;


### PR DESCRIPTION
A URL object will have an undefined search parameter in most instances. It works fine with the fallback method.

This should prevent uploading issues on upgraded WK iOS browsers that understand the `URL` object.