### PR TITLE
Make maximum file size error message more human friendly

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -222,7 +222,7 @@
         return reject('Missing file');
       }
       if (fileConfig.maxFileSize && file.file.size > fileConfig.maxFileSize) {
-        return reject('File size too large. Maximum size allowed is ' + fileConfig.maxFileSize);
+        return reject('File size too large. Maximum size allowed is ' + readableFileSize(fileConfig.maxFileSize));
       }
       if (typeof file.name === 'undefined') {
         return reject('Missing attribute: name');


### PR DESCRIPTION
While working on a file upload for our app, noticed that error message was not very user friendly, e.g. "_File size too large. Maximum size allowed is 10485760_".

This little adjustment fixes that and makes it human readable:

_File size too large. Maximum size allowed is 10 MB_