### PR TITLE
Update evaporate.js

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -2066,6 +2066,7 @@
     // The key tries to give a signature to a file in the absence of its path.
     // "<filename>-<mimetype>-<modifieddate>-<filesize>"
     return [
+      fileUpload.name, // fix for parallel uploads of identical files
       fileUpload.file.name,
       fileUpload.file.type,
       dateISOString(fileUpload.file.lastModified),


### PR DESCRIPTION
In our project, we faced with the possibility to upload several identical files to one s3 bucket to the separate subfolders. This cause the s3 upload error: was uploaded the only first file from the list of identical files. This patch for the fix parallel uploads of identical files.