### PR TITLE
Fixed broken example for signing awsv4 in js.

### DIFF
--- a/example/awsv4_signing_example.js
+++ b/example/awsv4_signing_example.js
@@ -22,7 +22,7 @@ app.listen(8080, '127.0.0.1', function () {
 });
 
 app.use('/sign_auth', function (req, res) {
-  
+
   const timestamp = req.query.datetime.substr(0, 8);
 
   const dateKey = hmac('AWS4' + process.env.AWS_SECRET, timestamp);
@@ -34,13 +34,13 @@ app.use('/sign_auth', function (req, res) {
 
 	console.log('Created signature "' + signature + '" from ' + req.query.to_sign);
 	res.send(signature);
-  
+
   // ===========
-  
+
   function hmac(key, string){
-    crypto.createHmac('sha256', key);
-      hmac.end(string);
-      return hmac.read();
+    const hmac = crypto.createHmac('sha256', key);
+    hmac.end(string);
+    return hmac.read();
   }
 });
 


### PR DESCRIPTION
Hi,
first of all thank you for this great library!
I have been using your AWSv4 signing example for javascript and noticed that there is a tiny mistake in it which causes it to not work, so I created this PR to fix it.