### PR TITLE
Use URL.host when generating headers to sign

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1016,7 +1016,7 @@
     this.started = defer();
 
     this.awsUrl = awsUrl(this.con);
-    this.awsHost = uri(this.awsUrl).hostname;
+    this.awsHost = uri(this.awsUrl).host;
 
     var r = extend({}, request);
     if (fileUpload.contentType) {


### PR DESCRIPTION
`host` includes the port number (necessary for generating correct signatures when using S3 endpoints on non-standard ports) where `hostname` does not.