### PR TITLE
readableFileSize: correct units to bytes not bits

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -2097,7 +2097,7 @@
   function readableFileSize(size) {
     // Adapted from https://github.com/fkjaekel
     // https://github.com/TTLabs/EvaporateJS/issues/13
-    var units = ['B', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb'],
+    var units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
         i = 0;
     while(size >= 1024) {
       size /= 1024;


### PR DESCRIPTION
The `readableFileSize` method returned bit-based unit labels (kilobit, megabit, etc.), but `size` is measured in bytes. This change updates the units displayed to be consistent with the value used, which is in bytes.

Ref: https://github.com/TTLabs/EvaporateJS/issues/13