### PR TITLE
Support for non standard ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Evaporate
 =========
 
+## This branch allows to use Custom port for S3 endpoint
+
 [![Build Status](https://travis-ci.org/bikeath1337/EvaporateJS.svg?branch=master)](https://travis-ci.org/bikeath1337/EvaporateJS)
 [![Code Climate](https://codeclimate.com/github/TTLabs/EvaporateJS/badges/gpa.svg)](https://codeclimate.com/github/TTLabs/EvaporateJS)
 

--- a/evaporate.js
+++ b/evaporate.js
@@ -1017,6 +1017,15 @@
 
     this.awsUrl = awsUrl(this.con);
     this.awsHost = uri(this.awsUrl).hostname;
+      /*
+       * ShreeDee : for compatibility with S3 clones, that are hosted on a non std port. Add the port number
+       */
+      const port = uri(this.awsUrl).port;
+      
+      if (!!port && 80 != port && 443 != port) {
+          this.awsHost += (':' + port ); 
+      }
+
 
     var r = extend({}, request);
     if (fileUpload.contentType) {


### PR DESCRIPTION
Some time S3 clones (like minio) is running on custom ports. This fix allows us to specify the port in AWS URL