### PR TITLE
Removed blacklist header from canonical calc

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1769,9 +1769,14 @@
 
       addHeader('Host', awsRequest.awsHost);
 
-      if (this.request.contentType) {
-        addHeader('Content-Type', this.request.contentType || '');
-      }
+    /**
+     * Removed, reference `getHeaderBlacklist()` in https://github.com/aws/aws-sdk-php/blob/master/src/Signature/SignatureV4.php
+     *  "The following headers are not signed because signing these header would potentially cause a signature
+     *   mismatch when sending a request through a proxy or if modified at the HTTP client level."
+     */
+//       if (this.request.contentType) {
+//         addHeader('Content-Type', this.request.contentType || '');
+//       }
 
       var amzHeaders = this.request.x_amz_headers || {};
       for (var key in amzHeaders) {


### PR DESCRIPTION
In building a backend system to recreate and verify client request before signing them, I noticed the AWS SDK for PHP have blacklist of headers for those it will **not sign**.

As such, I have removed the `content-length` header from `AwsSignatureV4.prototype.canonicalHeaders` function to align with AWS's signature process.

AWS-SDK reference: https://github.com/aws/aws-sdk-php/blob/6ef06165ef815358d3e60872b4c9f6c10deb3816/src/Signature/SignatureV4.php#L40-L74