### PR TITLE
Adding support for custom port

### DIFF
--- a/evaporate.js
+++ b/evaporate.js
@@ -1018,6 +1018,11 @@
     this.awsUrl = awsUrl(this.con);
     this.awsHost = uri(this.awsUrl).host;
 
+    const port = uri(this.awsUrl).port;
+    if (!!port && 80 != port && 443 != port) {
+      this.awsHost += (':' + port);
+    }
+
     var r = extend({}, request);
     if (fileUpload.contentType) {
       r.contentType = fileUpload.contentType;


### PR DESCRIPTION
For S3 alternatives such as MinIO, we may require to use custom port other than 80/443. 
This below changes will make sure evaporate.js works for non standard ports also.